### PR TITLE
fix segfault with unknown rclass

### DIFF
--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -56,7 +56,7 @@ std::string FilenameFromCore(RCore *core)
 std:: string CompilerFromCore(RCore *core)
 {
 	RBinInfo *info = r_bin_get_info(core->bin);
-	if (!info)
+	if (!info || !info->rclass)
 		return std::string("");
 
 	auto comp_it = compiler_map.find(info->rclass);


### PR DESCRIPTION
related to https://github.com/thestr4ng3r/r2ghidra-dec/issues/9
Not providing rclass or os information will result as a less good decompilation output.