### PR TITLE
Basic arm16 / thumb support

### DIFF
--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -47,7 +47,8 @@ static const std::map<std::string, std::string> cc_map = {
 		{ "fastcall", "__fastcall" },
 		{ "stdcall", "__stdcall" },
 		{ "cdecl-thiscall-ms", "__thiscall" },
-		{ "amd64", "__stdcall" }
+		{ "amd64", "__stdcall" },
+		{ "arm16", "__stdcall" } /* not actually __stdcall */
 };
 
 std::string FilenameFromCore(RCore *core)


### PR DESCRIPTION
Basic arm16 / thumb support.
Note use "e r2ghidra.lang=ARM:LE:32:Cortex" for correct Thumb decompiling