### PR TITLE
Fix syntax highlighting of paired keywords

### DIFF
--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -93,6 +93,7 @@ static const std::map<std::string, std::vector <void (*)(ANNOTATOR_PARAMS)> > an
 	{ "variable", { AnnotateColor } },
 	{ "funcname", { AnnotateColor } },
 	{ "type", { AnnotateColor } },
+	{ "syntax", { AnnotateColor } }
 };
 
 //#define TEST_UNKNOWN_NODES


### PR DESCRIPTION
This commit fixes a bug where do-while and if-else constructs
are not fully highlighted. Only the first opening keyword (i.e. `while`,
`if`) will be tagged by ghidra's XML as `<op>`. The secondary keywords
(i.e. `do` and `else`) are enclosed inside `<syntax>` tags.

To reproduce the bug/see the fix use the enclosed binary and check `s sym.rot13; pdg`.

[bin.zip](https://github.com/radareorg/r2ghidra-dec/files/3639865/bin.zip)
