### PR TITLE
Register "ms" CC in radare2 as "__fastcall" CC in ghidra

### DIFF
--- a/src/R2Architecture.cpp
+++ b/src/R2Architecture.cpp
@@ -18,6 +18,7 @@
 static const std::map<std::string, std::string> cc_map = {
 		{ "cdecl", "__cdecl" },
 		{ "fastcall", "__fastcall" },
+		{ "ms", "__fastcall" },
 		{ "stdcall", "__stdcall" },
 		{ "cdecl-thiscall-ms", "__thiscall" },
 		{ "sh32", "__stdcall" },


### PR DESCRIPTION
Since they are the same AFAIK.

Definition of `ms` in [radare2](https://github.com/radareorg/radare2/blob/5b392de33b84a4fd497cfda9d1af5b7b6333a963/libr/anal/d/cc-x86-64.sdb.txt#L3) and `__fastcall` in [ghidra](https://github.com/NationalSecurityAgency/ghidra/blob/decb362234d3ddfead76394b521e5669d2afac05/Ghidra/Processors/x86/data/languages/x86-64-win.cspec#L40), which should both representing [this](https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019).