### PR TITLE
Honor asm.flags.real in output

### DIFF
--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -379,8 +379,12 @@ FunctionSymbol *R2Scope::registerFunction(RAnalFunction *fcn) const
 
 Symbol *R2Scope::registerFlag(RFlagItem *flag) const
 {
+	RCoreLock core(arch);
+
 	uint4 attr = Varnode::namelock | Varnode::typelock;
 	Datatype *type = nullptr;
+	// Check whether flags should be displayed by their real name
+	bool realnameEnabled = r_config_get_i(core->config, "asm.flags.real");
 	if(flag->space && !strcmp(flag->space->name, R_FLAGS_FS_STRINGS))
 	{
 		Datatype *ptype = arch->types->findByName("char");
@@ -395,7 +399,7 @@ Symbol *R2Scope::registerFlag(RFlagItem *flag) const
 		type = arch->types->getTypeCode();
 	}
 
-	SymbolEntry *entry = cache->addSymbol(flag->name, type, Address(arch->getDefaultSpace(), flag->offset), Address());
+	SymbolEntry *entry = cache->addSymbol(realnameEnabled ? flag->realname : flag->name, type, Address(arch->getDefaultSpace(), flag->offset), Address());
 	if(!entry)
 		return nullptr;
 

--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -384,7 +384,7 @@ Symbol *R2Scope::registerFlag(RFlagItem *flag) const
 	uint4 attr = Varnode::namelock | Varnode::typelock;
 	Datatype *type = nullptr;
 	// Check whether flags should be displayed by their real name
-	bool realnameEnabled = r_config_get_i(core->config, "asm.flags.real");
+	bool realname_enabled = r_config_get_i(core->config, "asm.flags.real");
 	if(flag->space && !strcmp(flag->space->name, R_FLAGS_FS_STRINGS))
 	{
 		Datatype *ptype = arch->types->findByName("char");

--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -399,7 +399,7 @@ Symbol *R2Scope::registerFlag(RFlagItem *flag) const
 		type = arch->types->getTypeCode();
 	}
 
-	SymbolEntry *entry = cache->addSymbol(realnameEnabled ? flag->realname : flag->name, type, Address(arch->getDefaultSpace(), flag->offset), Address());
+	SymbolEntry *entry = cache->addSymbol(realname_enabled && flag->realname ? flag->realname : flag->name, type, Address(arch->getDefaultSpace(), flag->offset), Address());
 	if(!entry)
 		return nullptr;
 


### PR DESCRIPTION
This PR will make r2ghidra-dec honor realnames if asm.flags.real is set

**Before:**
```
...
uVar4 = (*_sym.imp.KERNEL32.dll_FindResourceW)(0, arg_8h_00 + 0x76U & 0xffff, 10);
uVar5 = (*_sym.imp.KERNEL32.dll_LoadResource)(0, uVar4);
uVar6 = (*_sym.imp.KERNEL32.dll_SizeofResource)(0, uVar4);
iVar7 = (*_sym.imp.KERNEL32.dll_LockResource)(uVar5);
...
```

**After:**
```
....
uVar4 = (*_FindResourceW)(0, arg_8h_00 + 0x76U & 0xffff, 10);
uVar5 = (*_LoadResource)(0, uVar4);
uVar6 = (*_SizeofResource)(0, uVar4);
iVar7 = (*_LockResource)(uVar5);
...
```


closes #68 