### PR TITLE
Allow user to use system pugixml library

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,8 +1,12 @@
+option(USE_SYSTEM_PUGIXML "Use system pugixml library" OFF)
 
-add_library(pugixml STATIC
-		pugixml/src/pugiconfig.hpp
-		pugixml/src/pugixml.cpp
-		pugixml/src/pugixml.hpp)
-target_include_directories(pugixml PUBLIC pugixml/src)
-set_target_properties(pugixml PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
+if (USE_SYSTEM_PUGIXML)
+	find_package(pugixml REQUIRED)
+else()
+	add_library(pugixml STATIC
+			pugixml/src/pugiconfig.hpp
+			pugixml/src/pugixml.cpp
+			pugixml/src/pugixml.hpp)
+	target_include_directories(pugixml PUBLIC pugixml/src)
+	set_target_properties(pugixml PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()


### PR DESCRIPTION
**Detailed description**
I want to package this for Fedora and distributions usually want to use as much as possible system libraries. As pugixml is available in Fedora, I want to be able to use that and this patch makes it possible by adding a new cmake option `USE_SYSTEM_PUGIXML`.

**Test plan**
Use `cmake -DUSE_SYSTEM_PUGIXML=ON ..` with pugixml-devel installed (or similar) and install the plugin. It should work as usual.
