### PR TITLE
fix Undefined symbols on macOS

### DIFF
--- a/src/AnnotatedCode.h
+++ b/src/AnnotatedCode.h
@@ -2,9 +2,15 @@
 #ifndef R2GHIDRA_ANNOTATEDCODE_H
 #define R2GHIDRA_ANNOTATEDCODE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_core.h>
 #include <r_types.h>
 #include <r_vector.h>
+#ifdef __cplusplus
+}
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ArchMap.h
+++ b/src/ArchMap.h
@@ -3,7 +3,13 @@
 #ifndef R2GHIDRA_ARCHMAP_H
 #define R2GHIDRA_ARCHMAP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_core.h>
+#ifdef __cplusplus
+}
+#endif
 
 #include <string>
 

--- a/src/R2CommentDatabase.cpp
+++ b/src/R2CommentDatabase.cpp
@@ -3,7 +3,13 @@
 #include "R2CommentDatabase.h"
 #include "R2Architecture.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_core.h>
+#ifdef __cplusplus
+}
+#endif
 
 #include "R2Utils.h"
 

--- a/src/R2LoadImage.h
+++ b/src/R2LoadImage.h
@@ -5,7 +5,13 @@
 
 #include "loadimage.hh"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_core.h>
+#ifdef __cplusplus
+}
+#endif
 
 // Windows defines LoadImage to LoadImageA
 #ifdef LoadImage

--- a/src/R2Scope.cpp
+++ b/src/R2Scope.cpp
@@ -6,8 +6,14 @@
 
 #include <funcdata.hh>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_anal.h>
 #include <r_core.h>
+#ifdef __cplusplus
+}
+#endif
 
 #include "R2Utils.h"
 

--- a/src/R2TypeFactory.cpp
+++ b/src/R2TypeFactory.cpp
@@ -3,8 +3,14 @@
 #include "R2TypeFactory.h"
 #include "R2Architecture.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_parse.h>
 #include <r_core.h>
+#ifdef __cplusplus
+}
+#endif
 
 #include "R2Utils.h"
 

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -12,7 +12,13 @@
 #include <libdecomp.hh>
 #include <printc.hh>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <r_core.h>
+#ifdef __cplusplus
+}
+#endif
 
 #include <vector>
 #include <mutex>


### PR DESCRIPTION
closes #94

wrap r2 includes in extern c, as they are c libraries, and not C++

<!--- Filling this template is mandatory -->

**Detailed description**

fixes #94 by wrapping all the c includes in extern C

```c
#ifdef __cplusplus
extern "C" {
#endif
// blah blah blah
#ifdef __cplusplus
}
#endif
```

...

**Test plan**
tested that it builds on macOS, untested on other platforms, but it shouldn't make any issues anywhere.

...

**Closing issues**

closes #94 

...
