### PR TITLE
Use Debian instead of Ubuntu for Travis and build the Debian package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - master
 
 os: linux
-dist: bionic
+dist: trusty
 
 addons:
   apt:
@@ -48,4 +48,9 @@ script:
   - export R2_LIBR_PLUGINS="$INSTALL_PREFIX/share/radare2/plugins"
   - cd ../test
   - NOOK=0 make
+
+after_success:
+  - make -C dist/debian
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - compgen -G dist/debian/*.deb > /dev/null && bash upload.sh dist/debian/*.deb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - master
 
 os: linux
-dist: trusty
+dist: stretch
 
 addons:
   apt:


### PR DESCRIPTION
**Detailed description**

We need to build things on Debian distros, not ubuntu ones for portability reasons. i pick this one because its the same we are using in radare

But also we want to have the .deb files uploaded and not having to depend on the version of r2.

**Test plan**

Ideally it should use Gitlab CI

**Closing issues**
none
