### PR TITLE
Implemented offset annotation for comments

### DIFF
--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -47,6 +47,20 @@ void AnnotateOpref(ANNOTATOR_PARAMS)
 	annotation.offset.offset = op->getAddr().getOffset();
 }
 
+void AnnotateCommentOffset(ANNOTATOR_PARAMS){
+	pugi::xml_attribute attr = node.attribute("off");
+	if(attr.empty())
+		return;
+	unsigned long long off = attr.as_ullong(ULLONG_MAX);
+	if(off == ULLONG_MAX)
+		return;
+	out->emplace_back();
+	auto &annotation = out->back();
+	annotation = {};
+	annotation.type = R_CODE_ANNOTATION_TYPE_OFFSET;
+	annotation.offset.offset = off;
+}
+
 /**
  * Translate Ghidra's color annotations, which are essentially
  * loose token classes of the high level decompiled source code.
@@ -89,7 +103,7 @@ void AnnotateColor(ANNOTATOR_PARAMS)
 static const std::map<std::string, std::vector <void (*)(ANNOTATOR_PARAMS)> > annotators = {
 	{ "statement", { AnnotateOpref } },
 	{ "op", { AnnotateOpref, AnnotateColor } },
-	{ "comment", { AnnotateColor } },
+	{ "comment", { AnnotateCommentOffset, AnnotateColor } },
 	{ "variable", { AnnotateColor } },
 	{ "funcname", { AnnotateColor } },
 	{ "type", { AnnotateColor } },

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -1329,3 +1329,34 @@ af
 pdg
 EOF
 RUN
+
+NAME=comments-offset
+FILE=r2-testbins/elf/crackme0x05
+EXPECT=<<EOF
+                  |
+                  |undefined4 main(void)
+                  |{
+                  |    int32_t var_78h;
+                  |    
+    0x08048540    |    // main starts here
+    0x08048566    |    // printf call here
+    0x08048566    |    sym.imp.printf("IOLI Crackme Level 0x05\n");
+    0x08048572    |    sym.imp.printf("Password: ");
+    0x08048585    |    // scanf call here
+    0x08048585    |    sym.imp.scanf(0x80486b2, &var_78h);
+    0x0804858a    |    sym.check((int32_t)&var_78h);
+    0x0804859b    |    // main returns here
+    0x0804859b    |    return 0;
+                  |}
+EOF
+CMDS=<<EOF
+CCu base64:bWFpbiBzdGFydHMgaGVyZQ== @ 0x08048540
+CCu base64:cHJpbnRmIGNhbGwgaGVyZQ== @ 0x08048566
+CCu base64:bWFpbiByZXR1cm5zIGhlcmU= @ 0x0804859b
+CCu base64:bm90aGluZyB0byBzZWUgaGVyZQ== @ 0x0804859c
+CCu base64:c2NhbmYgY2FsbCBoZXJl @ 0x08048585
+s main
+af
+pdgo
+EOF
+RUN

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -1018,8 +1018,8 @@ NAME=pdgo align
 FILE=r2-testbins/elf/hello_world
 ARGS=-B 0x1000000000000000
 EXPECT=<<EOF
-                          |
-                          |// WARNING: [r2ghidra] Detected overlap for variable var_1ch
+    0x10000000000007aa    |
+    0x10000000000007aa    |// WARNING: [r2ghidra] Detected overlap for variable var_1ch
                           |
                           |void main(void)
                           |{


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

### **Detailed description**

Earlier we didn't have offset annotation (`R_CODE_ANNOTATION_TYPE_OFFSET`) for comments. Because of this, we have inconsistent behavior while clicking on a comment to edit in Cutter. This PR solves this problem by implementing offset annotations for comments.

The following GIFs show the previous behavior and improved behavior.
[Note: The following GIFs don't use the current master of Cutter. The same behavior can be noticed from the master also. So this PR can be merged after testing]

**Before having offset annotation**
![BeforeCommentOffset](https://user-images.githubusercontent.com/18501167/85844514-7a332f00-b7c0-11ea-8269-4ebb034991fa.gif)
**After implementing offset annotation**
![AfterCommentOffset_1](https://user-images.githubusercontent.com/18501167/85844548-88814b00-b7c0-11ea-9f33-1f460757c9f3.gif)



<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**
- Test with the current master of Cutter
- Test if the changes are working as expected
- Make sure nothing else is affected by this change
<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
