### PR TITLE
Annotation for constant and global variables

### DIFF
--- a/scripts/Dockerfile.jessie
+++ b/scripts/Dockerfile.jessie
@@ -4,7 +4,7 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get -y install git g++ cmake pkg-config flex bison
 
-RUN cd /root &&  git clone --depth 1 --single-branch --branch decompiler-refactoring https://github.com/radareorg/radare2 && cd radare2 && ./configure && make -j4 && make install
+RUN cd /root && git clone --depth 1 --single-branch --branch decompiler-refactoring https://github.com/radareorg/radare2 && cd radare2 && ./configure && make -j4 && make install
 
 CMD []
 

--- a/scripts/Dockerfile.jessie
+++ b/scripts/Dockerfile.jessie
@@ -4,7 +4,7 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get -y install git g++ cmake pkg-config flex bison
 
-RUN cd /root && git clone --depth 1 --single-branch --branch decompiler-refactoring https://github.com/radareorg/radare2 && cd radare2 && ./configure && make -j4 && make install
+RUN cd /root &&  git clone --depth 1 --single-branch --branch decompiler-refactoring https://github.com/radareorg/radare2 && cd radare2 && ./configure && make -j4 && make install
 
 CMD []
 

--- a/scripts/Dockerfile.jessie
+++ b/scripts/Dockerfile.jessie
@@ -4,7 +4,7 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get -y install git g++ cmake pkg-config flex bison
 
-RUN cd /root && git clone https://github.com/radareorg/radare2 && cd radare2 && ./configure && make -j4 && make install
+RUN cd /root && git clone https://github.com/radareorg/radare2 && cd radare2 && git checkout decompiler-refactoring && ./configure && make -j4 && make install
 
 CMD []
 

--- a/scripts/Dockerfile.jessie
+++ b/scripts/Dockerfile.jessie
@@ -4,7 +4,7 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get -y install git g++ cmake pkg-config flex bison
 
-RUN cd /root && git clone https://github.com/radareorg/radare2 && cd radare2 && git checkout decompiler-refactoring && ./configure && make -j4 && make install
+RUN cd /root && git clone --depth 1 --single-branch --branch decompiler-refactoring https://github.com/radareorg/radare2 && cd radare2 && ./configure && make -j4 && make install
 
 CMD []
 

--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -67,13 +67,13 @@ void AnnotateFunctionName(ANNOTATOR_PARAMS)
 	{
 		if(ctx->func->getName() == func_name)
 		{
-			annotation.function_name.name = strdup(ctx->func->getName().c_str());
-			annotation.function_name.offset = ctx->func->getAddress().getOffset();
+			annotation.reference.name = strdup(ctx->func->getName().c_str());
+			annotation.reference.offset = ctx->func->getAddress().getOffset();
 			out->push_back(annotation);
 			// Code below makes an offset annotation for the function name(for the currently decompiled function)
 			RCodeAnnotation offsetAnnotation = {};
 			offsetAnnotation.type = R_CODE_ANNOTATION_TYPE_OFFSET;
-			offsetAnnotation.offset.offset = annotation.function_name.offset;
+			offsetAnnotation.offset.offset = annotation.reference.offset;
 			out->push_back(offsetAnnotation);
 		}
 		return;
@@ -92,8 +92,8 @@ void AnnotateFunctionName(ANNOTATOR_PARAMS)
 	FuncCallSpecs *call_func_spec = ctx->func->getCallSpecs(op);
 	if(call_func_spec)
 	{
-		annotation.function_name.name = strdup(call_func_spec->getName().c_str());
-		annotation.function_name.offset = call_func_spec->getEntryAddress().getOffset();
+		annotation.reference.name = strdup(call_func_spec->getName().c_str());
+		annotation.reference.offset = call_func_spec->getEntryAddress().getOffset();
 		out->push_back(annotation);
 	}
 }
@@ -165,14 +165,14 @@ void AnnotateVariable(ANNOTATOR_PARAMS)
 	{
 		RCodeAnnotation annotation = {};
 		annotation.type = R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE;
-		annotation.global_variable.offset = varnode->getOffset();
+		annotation.reference.offset = varnode->getOffset();
 		out->push_back(annotation);
 	}
 	else if(varnode->getHigh()->isConstant() && varnode->getSpace()->getName()=="ram")
 	{
 		RCodeAnnotation annotation = {};
 		annotation.type = R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
-		annotation.constant_variable.offset = varnode->getOffset();
+		annotation.reference.offset = varnode->getOffset();
 		out->push_back(annotation);
 	}
 }

--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -168,7 +168,7 @@ void AnnotateVariable(ANNOTATOR_PARAMS)
 		annotation.reference.offset = varnode->getOffset();
 		out->push_back(annotation);
 	}
-	else if(varnode->getHigh()->isConstant() && varnode->getSpace()->getName()=="ram")
+	else if(varnode->getHigh()->isConstant() && varnode->getSpace()->getName() == "ram")
 	{
 		RCodeAnnotation annotation = {};
 		annotation.type = R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;

--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -161,15 +161,18 @@ void AnnotateVariable(ANNOTATOR_PARAMS)
 	if(varref == ULLONG_MAX)
 		return;
 	Varnode *varnode = getVarnodeForVariable(varref, ctx);
-	if(varnode->getHigh()->isConstant() && varnode->getSpace()->getName()=="ram"){
-		RCodeAnnotation annotation = {};
-		annotation.type = R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
-		annotation.constant_variable.offset = varnode->getOffset();
-		out->push_back(annotation);
-	}else if(varnode->getHigh()->isPersist() && varnode->getHigh()->isAddrTied()){
+	if(varnode->getHigh()->isPersist() && varnode->getHigh()->isAddrTied())
+	{
 		RCodeAnnotation annotation = {};
 		annotation.type = R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE;
 		annotation.global_variable.offset = varnode->getOffset();
+		out->push_back(annotation);
+	}
+	else if(varnode->getHigh()->isConstant() && varnode->getSpace()->getName()=="ram")
+	{
+		RCodeAnnotation annotation = {};
+		annotation.type = R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
+		annotation.constant_variable.offset = varnode->getOffset();
 		out->push_back(annotation);
 	}
 }

--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -161,13 +161,11 @@ void AnnotateVariable(ANNOTATOR_PARAMS)
 	if(varref == ULLONG_MAX)
 		return;
 	Varnode *varnode = getVarnodeForVariable(varref, ctx);
-	if(varnode->getHigh()->isConstant()){
-		if(varnode->getSpace()->getName()=="ram"){
-			RCodeAnnotation annotation = {};
-			annotation.type = R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
-			annotation.constant_variable.offset = varnode->getOffset();
-			out->push_back(annotation);
-		}
+	if(varnode->getHigh()->isConstant() && varnode->getSpace()->getName()=="ram"){
+		RCodeAnnotation annotation = {};
+		annotation.type = R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE;
+		annotation.constant_variable.offset = varnode->getOffset();
+		out->push_back(annotation);
 	}else if(varnode->getHigh()->isPersist() && varnode->getHigh()->isAddrTied()){
 		RCodeAnnotation annotation = {};
 		annotation.type = R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE;
@@ -185,8 +183,6 @@ static const std::map<std::string, std::vector <void (*)(ANNOTATOR_PARAMS)> > an
 	{ "type", { AnnotateColor } },
 	{ "syntax", { AnnotateColor } }
 };
-
-
 
 //#define TEST_UNKNOWN_NODES
 

--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -142,16 +142,37 @@ void AnnotateColor(ANNOTATOR_PARAMS)
 	annotation.syntax_highlight.type = type;
 	out->push_back(annotation);
 }
+static Varnode *getVarnodeForVariable(unsigned long long varref, ParseCodeXMLContext *ctx)
+{
+	for(auto it = ctx->func->beginLoc(); it != ctx->func->endLoc(); it++)
+	{
+		if((*it)->getCreateIndex() == varref)
+			return *it;
+	}
+}
+
+void AnnotateVariable(ANNOTATOR_PARAMS)
+{
+	pugi::xml_attribute attr = node.attribute("varref");
+	if(attr.empty())
+		return;
+	unsigned long long varref = attr.as_ullong(ULLONG_MAX);
+	if(varref == ULLONG_MAX)
+		return;
+	Varnode *varnode = getVarnodeForVariable(varref, ctx);
+}
 
 static const std::map<std::string, std::vector <void (*)(ANNOTATOR_PARAMS)> > annotators = {
 	{ "statement", { AnnotateOpref } },
 	{ "op", { AnnotateOpref, AnnotateColor } },
 	{ "comment", { AnnotateCommentOffset, AnnotateColor } },
-	{ "variable", { AnnotateColor } },
+	{ "variable", { AnnotateVariable, AnnotateColor } },
 	{ "funcname", { AnnotateFunctionName, AnnotateColor } },
 	{ "type", { AnnotateColor } },
 	{ "syntax", { AnnotateColor } }
 };
+
+
 
 //#define TEST_UNKNOWN_NODES
 

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -342,6 +342,523 @@ pdgj~{}
 EOF
 RUN
 
+NAME=constant variable annotation
+FILE=bins/dectest32
+EXPECT=<<EOF
+{
+  "code": "\nvoid sym.PrintAmbassador(int32_t arg_8h)\n{\n    func_0x08049050(\"Ambassador value: \");\n    switch(arg_8h) {\n    case 0:\n        func_0x08049050(\"pure\");\n        break;\n    case 1:\n        func_0x08049050(\"reason\");\n        break;\n    case 2:\n        func_0x08049050(\"revolution\");\n        break;\n    case 3:\n        func_0x08049050(\"echoes\");\n        break;\n    case 4:\n        func_0x08049050(\"wall\");\n        break;\n    default:\n        if (arg_8h == 1000000) {\n            func_0x08049050(\"million\");\n        }\n        break;\n    case -0x452e541f:\n        break;\n    }\n    func_0x08049090(10);\n    return;\n}\n",
+  "annotations": [
+    {
+      "start": 1,
+      "end": 5,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 6,
+      "end": 25,
+      "type": "function_name",
+      "name": "sym.PrintAmbassador",
+      "offset": 134517281
+    },
+    {
+      "start": 6,
+      "end": 25,
+      "type": "offset",
+      "offset": 134517281
+    },
+    {
+      "start": 6,
+      "end": 25,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 26,
+      "end": 33,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 34,
+      "end": 40,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_parameter"
+    },
+    {
+      "start": 48,
+      "end": 63,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 48,
+      "end": 63,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 64,
+      "end": 84,
+      "type": "constant_variable",
+      "offset": 134520840
+    },
+    {
+      "start": 64,
+      "end": 84,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 48,
+      "end": 85,
+      "type": "offset",
+      "offset": 134517295
+    },
+    {
+      "start": 91,
+      "end": 97,
+      "type": "offset",
+      "offset": 134517332
+    },
+    {
+      "start": 91,
+      "end": 97,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 98,
+      "end": 104,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_parameter"
+    },
+    {
+      "start": 112,
+      "end": 116,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 117,
+      "end": 118,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 128,
+      "end": 143,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 128,
+      "end": 143,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 144,
+      "end": 150,
+      "type": "constant_variable",
+      "offset": 134520859
+    },
+    {
+      "start": 144,
+      "end": 150,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 128,
+      "end": 151,
+      "type": "offset",
+      "offset": 134517353
+    },
+    {
+      "start": 161,
+      "end": 166,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 161,
+      "end": 167,
+      "type": "offset",
+      "offset": 134517361
+    },
+    {
+      "start": 172,
+      "end": 176,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 177,
+      "end": 178,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 188,
+      "end": 203,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 188,
+      "end": 203,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 204,
+      "end": 212,
+      "type": "constant_variable",
+      "offset": 134520864
+    },
+    {
+      "start": 204,
+      "end": 212,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 188,
+      "end": 213,
+      "type": "offset",
+      "offset": 134517371
+    },
+    {
+      "start": 223,
+      "end": 228,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 223,
+      "end": 229,
+      "type": "offset",
+      "offset": 134517379
+    },
+    {
+      "start": 234,
+      "end": 238,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 239,
+      "end": 240,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 250,
+      "end": 265,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 250,
+      "end": 265,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 266,
+      "end": 278,
+      "type": "constant_variable",
+      "offset": 134520871
+    },
+    {
+      "start": 266,
+      "end": 278,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 250,
+      "end": 279,
+      "type": "offset",
+      "offset": 134517389
+    },
+    {
+      "start": 289,
+      "end": 294,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 289,
+      "end": 295,
+      "type": "offset",
+      "offset": 134517397
+    },
+    {
+      "start": 300,
+      "end": 304,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 305,
+      "end": 306,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 316,
+      "end": 331,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 316,
+      "end": 331,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 332,
+      "end": 340,
+      "type": "constant_variable",
+      "offset": 134520882
+    },
+    {
+      "start": 332,
+      "end": 340,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 316,
+      "end": 341,
+      "type": "offset",
+      "offset": 134517407
+    },
+    {
+      "start": 351,
+      "end": 356,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 351,
+      "end": 357,
+      "type": "offset",
+      "offset": 134517415
+    },
+    {
+      "start": 362,
+      "end": 366,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 367,
+      "end": 368,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 378,
+      "end": 393,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 378,
+      "end": 393,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 394,
+      "end": 400,
+      "type": "constant_variable",
+      "offset": 134520889
+    },
+    {
+      "start": 394,
+      "end": 400,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 378,
+      "end": 401,
+      "type": "offset",
+      "offset": 134517425
+    },
+    {
+      "start": 411,
+      "end": 416,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 411,
+      "end": 417,
+      "type": "offset",
+      "offset": 134517433
+    },
+    {
+      "start": 422,
+      "end": 429,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 439,
+      "end": 441,
+      "type": "offset",
+      "offset": 134517341
+    },
+    {
+      "start": 439,
+      "end": 441,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 443,
+      "end": 449,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_parameter"
+    },
+    {
+      "start": 450,
+      "end": 452,
+      "type": "offset",
+      "offset": 134517334
+    },
+    {
+      "start": 453,
+      "end": 460,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 476,
+      "end": 491,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516816
+    },
+    {
+      "start": 476,
+      "end": 491,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 492,
+      "end": 501,
+      "type": "constant_variable",
+      "offset": 134520894
+    },
+    {
+      "start": 492,
+      "end": 501,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 476,
+      "end": 502,
+      "type": "offset",
+      "offset": 134517443
+    },
+    {
+      "start": 522,
+      "end": 527,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 533,
+      "end": 537,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 538,
+      "end": 549,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 559,
+      "end": 564,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 559,
+      "end": 565,
+      "type": "offset",
+      "offset": 134517332
+    },
+    {
+      "start": 576,
+      "end": 591,
+      "type": "function_name",
+      "name": "",
+      "offset": 134516880
+    },
+    {
+      "start": 576,
+      "end": 591,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 592,
+      "end": 594,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 576,
+      "end": 595,
+      "type": "offset",
+      "offset": 134517459
+    },
+    {
+      "start": 601,
+      "end": 607,
+      "type": "offset",
+      "offset": 134517469
+    },
+    {
+      "start": 601,
+      "end": 607,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 601,
+      "end": 607,
+      "type": "offset",
+      "offset": 134517469
+    }
+  ]
+}
+EOF
+CMDS=<<EOF
+s sym.PrintAmbassador
+af
+pdgj~{}
+EOF
+RUN
+
 NAME=aeropause32 (many features combined)
 FILE=bins/dectest32
 EXPECT=<<EOF

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -256,12 +256,89 @@ RUN
 NAME=global variable annotation
 FILE=bins/dectest32
 EXPECT=<<EOF
-{"code":"\nundefined4 sym.get_global_array_entry(void)\n{\n    return *(undefined4 *)0x804c034;\n}\n","annotations":[{"start":1,"end":11,"type":"syntax_highlight","syntax_highlight":"datatype"},{"start":12,"end":38,"type":"function_name","name":"sym.get_global_array_entry","offset":134517184},{"start":12,"end":38,"type":"offset","offset":134517184},{"start":12,"end":38,"type":"syntax_highlight","syntax_highlight":"function_name"},{"start":39,"end":43,"type":"syntax_highlight","syntax_highlight":"keyword"},{"start":51,"end":57,"type":"offset","offset":134517193},{"start":51,"end":57,"type":"syntax_highlight","syntax_highlight":"keyword"},{"start":58,"end":59,"type":"offset","offset":134517187},{"start":60,"end":70,"type":"syntax_highlight","syntax_highlight":"datatype"},{"start":73,"end":82,"type":"global_variable","offset":134529076},{"start":73,"end":82,"type":"syntax_highlight","syntax_highlight":"constant_variable"},{"start":51,"end":82,"type":"offset","offset":134517193}]}
+{
+  "code": "\nundefined4 sym.get_global_array_entry(void)\n{\n    return *(undefined4 *)0x804c034;\n}\n",
+  "annotations": [
+    {
+      "start": 1,
+      "end": 11,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 12,
+      "end": 38,
+      "type": "function_name",
+      "name": "sym.get_global_array_entry",
+      "offset": 134517184
+    },
+    {
+      "start": 12,
+      "end": 38,
+      "type": "offset",
+      "offset": 134517184
+    },
+    {
+      "start": 12,
+      "end": 38,
+      "type": "syntax_highlight",
+      "syntax_highlight": "function_name"
+    },
+    {
+      "start": 39,
+      "end": 43,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 51,
+      "end": 57,
+      "type": "offset",
+      "offset": 134517193
+    },
+    {
+      "start": 51,
+      "end": 57,
+      "type": "syntax_highlight",
+      "syntax_highlight": "keyword"
+    },
+    {
+      "start": 58,
+      "end": 59,
+      "type": "offset",
+      "offset": 134517187
+    },
+    {
+      "start": 60,
+      "end": 70,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 73,
+      "end": 82,
+      "type": "global_variable",
+      "offset": 134529076
+    },
+    {
+      "start": 73,
+      "end": 82,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 51,
+      "end": 82,
+      "type": "offset",
+      "offset": 134517193
+    }
+  ]
+}
 EOF
 CMDS=<<EOF
 s sym.get_global_array_entry
 af
-pdgj
+pdgj~{}
 EOF
 RUN
 

--- a/test/db/extras/r2ghidra
+++ b/test/db/extras/r2ghidra
@@ -253,6 +253,18 @@ pdg
 EOF
 RUN
 
+NAME=global variable annotation
+FILE=bins/dectest32
+EXPECT=<<EOF
+{"code":"\nundefined4 sym.get_global_array_entry(void)\n{\n    return *(undefined4 *)0x804c034;\n}\n","annotations":[{"start":1,"end":11,"type":"syntax_highlight","syntax_highlight":"datatype"},{"start":12,"end":38,"type":"function_name","name":"sym.get_global_array_entry","offset":134517184},{"start":12,"end":38,"type":"offset","offset":134517184},{"start":12,"end":38,"type":"syntax_highlight","syntax_highlight":"function_name"},{"start":39,"end":43,"type":"syntax_highlight","syntax_highlight":"keyword"},{"start":51,"end":57,"type":"offset","offset":134517193},{"start":51,"end":57,"type":"syntax_highlight","syntax_highlight":"keyword"},{"start":58,"end":59,"type":"offset","offset":134517187},{"start":60,"end":70,"type":"syntax_highlight","syntax_highlight":"datatype"},{"start":73,"end":82,"type":"global_variable","offset":134529076},{"start":73,"end":82,"type":"syntax_highlight","syntax_highlight":"constant_variable"},{"start":51,"end":82,"type":"offset","offset":134517193}]}
+EOF
+CMDS=<<EOF
+s sym.get_global_array_entry
+af
+pdgj
+EOF
+RUN
+
 NAME=aeropause32 (many features combined)
 FILE=bins/dectest32
 EXPECT=<<EOF


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**
This PR implements annotations for constant variables and global variables. The logic used to determine if a variable is global or constant is taken from the following [existing code](https://github.com/thestr4ng3r/ghidra/blob/6c10f36f06468f866188cccf960c019779fb9028/Ghidra/Features/Decompiler/src/decompile/cpp/variable.cc#L452-L470) in `variable.cc`. https://github.com/thestr4ng3r/ghidra/blob/6c10f36f06468f866188cccf960c019779fb9028/Ghidra/Features/Decompiler/src/decompile/cpp/variable.cc#L452-L470
As discussed in the Telegram channel, I'm making constant variable annotation only when address space is of name "ram". However, I couldn't find such a constant variable that satisfies this condition in the examples I have tried. I am not sure if such a constant variable would ever exist. Maybe all we want is global variables for the action to add/delete/rename flags in Cutter. 
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solvPR ers can review your pull request. -->

...

**Test plan**

- [ ] 1. Fetch and compile [PR #17281](https://github.com/radareorg/radare2/pull/17281) from radare2 and compile it before compiling this PR. 
- [ ] 2. Test if all global and constant variables are identified as expected by the `AnnotateVariable` function.
-  You can use the output of `pdgj` for testing if the variables and offsets are annotated correctly. The binary used in the new tests made added in this PR can be used for testing.

- [ ] 3. Check code and make sure my logic for determining if a variable is global/constant is correct.

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
