### PR TITLE
Fix windows build

### DIFF
--- a/cmake/FindRadare2.cmake
+++ b/cmake/FindRadare2.cmake
@@ -16,12 +16,20 @@
 #  Radare2_LIBRARY_<name> - Path to library r_<name>
 
 if(WIN32)
-	find_path(Radare2_INCLUDE_DIRS
-			NAMES r_core.h r_bin.h r_util.h
-			HINTS
-			"$ENV{HOME}/bin/prefix/radare2/include/libr"
-			/usr/local/include/libr
-			/usr/include/libr)
+        find_path(Radare2_INCLUDE_DIRS
+                        NAMES r_core.h r_bin.h r_util.h
+                        HINTS
+                        "$ENV{HOME}/bin/prefix/radare2/include/libr"
+                        /usr/local/include/libr
+                        /usr/include/libr)
+        find_path(SDB_INCLUDE_DIR
+                        NAMES sdb.h sdbht.h sdb_version.h
+                        HINTS
+                        "$ENV{HOME}/bin/prefix/radare2/include/libr/sdb"
+                        /usr/local/include/libr/sdb
+                        /usr/include/libr/sdb)
+
+        list(APPEND Radare2_INCLUDE_DIRS ${SDB_INCLUDE_DIR})
 
 	set(Radare2_LIBRARY_NAMES
 			core


### PR DESCRIPTION
**Detailed description**

The recent SDB header PR [#17249](https://github.com/radareorg/radare2/pull/17249/) requires us to add the sdb header's path separately from the other r2 headers. This broke Cutter's r2ghidra-dec windows build as you can see in this job https://ci.appveyor.com/project/radareorg/cutter/builds/34583435/job/98wog65qjgx9t4sf#L3091

**Test plan**

Build in Windows using msys.
