### PR TITLE
Implement decompiler isRunning() 

### DIFF
--- a/cutter-plugin/R2GhidraDecompiler.cpp
+++ b/cutter-plugin/R2GhidraDecompiler.cpp
@@ -12,11 +12,13 @@
 R2GhidraDecompiler::R2GhidraDecompiler(QObject *parent)
 	: Decompiler("r2ghidra", "Ghidra", parent)
 {
-	task = nullptr;
+	task = DecompilerFinished;
 }
 
 void R2GhidraDecompiler::decompileAt(ut64 addr)
 {
+	task = DecompilerRunning;
 	RAnnotatedCode *code = r2ghidra_decompile_annotated_code(Core()->core(), addr);
 	emit finished(code); //Here, we emit RAnnotatedCode *code or by value
+	task = DecompilerFinished;
 }

--- a/cutter-plugin/R2GhidraDecompiler.h
+++ b/cutter-plugin/R2GhidraDecompiler.h
@@ -8,13 +8,14 @@
 
 class R2GhidraDecompiler: public Decompiler
 {
+	enum DecompilerState {DecompilerRunning, DecompilerFinished};
 	private:
-		R2Task *task;
+		DecompilerState task;
 
 	public:
 		R2GhidraDecompiler(QObject *parent = nullptr);
 		void decompileAt(RVA addr) override;
-		bool isRunning() override				{ return task != nullptr; }
+		bool isRunning() override				{ return task != DecompilerFinished; }
 };
 
 #endif //R2GHIDRA_R2GHIDRADECOMPILER_H

--- a/cutter-plugin/R2GhidraDecompiler.h
+++ b/cutter-plugin/R2GhidraDecompiler.h
@@ -15,7 +15,7 @@ class R2GhidraDecompiler: public Decompiler
 	public:
 		R2GhidraDecompiler(QObject *parent = nullptr);
 		void decompileAt(RVA addr) override;
-		bool isRunning() override				{ return task != DecompilerFinished; }
+		bool isRunning() override				{ return task == DecompilerRunning; }
 };
 
 #endif //R2GHIDRA_R2GHIDRADECOMPILER_H


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Implementing decompiler `isRunning()` was missed out while refactoring the decompiler interface in r2ghidra-dec. This PR fixes it.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**
1. Check code.
2. Due to some regression as pointed out by @karliss [in this discussion,](https://github.com/radareorg/cutter/pull/2402#discussion_r475795188) this can't be tested right now. You can modify the code to maybe set `task = DecompilerRunning` to make sure the decompiler interface in Cutter able to get the required data from the r2ghidra-dec.
<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
