### PR TITLE
Fix crash when using r2ghidra from rasm2

### DIFF
--- a/src/anal_ghidra.cpp
+++ b/src/anal_ghidra.cpp
@@ -1750,7 +1750,8 @@ static void append_hardcoded_regs(std::stringstream &buf, const std::string &arc
 
 static char *get_reg_profile(RAnal *anal)
 {
-	ut64 length = strlen(anal->cpu), z = 0;
+	ut64 length = anal->cpu ? strlen(anal->cpu): 0;
+	ut64 z = 0;
 	for(; z < length && anal->cpu[z] != ':'; ++z) {}
 	if(z == length)
 		return nullptr;

--- a/test/db/extras/asm_ghidra
+++ b/test/db/extras/asm_ghidra
@@ -1,3 +1,12 @@
+NAME=v850
+FILE=-
+CMDS=<<EOF
+rasm2 -a r2ghidra -c V859 -d 8500c52a
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
 NAME=x86_32
 FILE=r2-testbins/elf/crackme0x05
 EXPECT=<<EOF


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

```
$ rasm2 -a r2ghidra -c V859 -d 8500c52a
zsh: segmentation fault  rasm2 -a r2ghidra -c V859 -d 8500c52a
$ lldb -- rasm2 -a r2ghidra -c V859 -d 8500c52a
(lldb) target create "rasm2"
r
Current executable set to 'rasm2' (x86_64).
(lldb) settings set -- target.run-args  "-a" "r2ghidra" "-c" "V859" "-d" "8500c52a"
(lldb) r
Process 15765 launched: '/usr/local/bin/rasm2' (x86_64)
Process 15765 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00007fff67857e52 libsystem_platform.dylib`_platform_strlen + 18
libsystem_platform.dylib`_platform_strlen:
->  0x7fff67857e52 <+18>: pcmpeqb (%rdi), %xmm0
    0x7fff67857e56 <+22>: pmovmskb %xmm0, %esi
    0x7fff67857e5a <+26>: andq   $0xf, %rcx
    0x7fff67857e5e <+30>: orq    $-0x1, %rax
Target 0: (rasm2) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x00007fff67857e52 libsystem_platform.dylib`_platform_strlen + 18
    frame #1: 0x0000000102e3f69b anal_ghidra.dylib`get_reg_profile(r_anal_t*) + 27
    frame #2: 0x0000000101491d5a libr_anal.dylib`r_anal_get_reg_profile(anal=0x000000010300a000) at anal.c:223:5
    frame #3: 0x0000000101491cab libr_anal.dylib`r_anal_set_reg_profile(anal=0x000000010300a000) at anal.c:232:13
    frame #4: 0x0000000101491c03 libr_anal.dylib`r_anal_use(anal=0x000000010300a000, name="r2ghidra") at anal.c:214:4
    frame #5: 0x0000000101da8b6d libr_main.dylib`r_main_rasm2(argc=7, argv=0x00007ffeefbff8f0) at rasm2.c:693:3
    frame #6: 0x0000000100003f82 rasm2`main(argc=7, argv=0x00007ffeefbff8f0) at rasm2.c:6:9
    frame #7: 0x00007fff67661cc9 libdyld.dylib`start + 1
(lldb) up
frame #1: 0x0000000102e3f69b anal_ghidra.dylib`get_reg_profile(r_anal_t*) + 27
anal_ghidra.dylib`get_reg_profile:
->  0x102e3f69b <+27>: movq   %rax, -0x18(%rbp)
    0x102e3f69f <+31>: movq   $0x0, -0x20(%rbp)
    0x102e3f6a7 <+39>: xorl   %eax, %eax
    0x102e3f6a9 <+41>: movq   -0x20(%rbp), %rcx
(lldb)
frame #2: 0x0000000101491d5a libr_anal.dylib`r_anal_get_reg_profile(anal=0x000000010300a000) at anal.c:223:5
   220
   221 	R_API char *r_anal_get_reg_profile(RAnal *anal) {
   222 		return (anal && anal->cur && anal->cur->get_reg_profile)
-> 223 			? anal->cur->get_reg_profile (anal) : NULL;
   224 	}
   225
   226 	// deprecate.. or at least reuse get_reg_profile...
(lldb) down
frame #1: 0x0000000102e3f69b anal_ghidra.dylib`get_reg_profile(r_anal_t*) + 27
anal_ghidra.dylib`get_reg_profile:
->  0x102e3f69b <+27>: movq   %rax, -0x18(%rbp)
    0x102e3f69f <+31>: movq   $0x0, -0x20(%rbp)
    0x102e3f6a7 <+39>: xorl   %eax, %eax
    0x102e3f6a9 <+41>: movq   -0x20(%rbp), %rcx
(lldb) r
There is a running process, kill it and restart?: [Y/n] y
Process 15765 exited with status = 9 (0x00000009)
Process 15894 launched: '/usr/local/bin/rasm2' (x86_64)
Can't get RCore from RAsm's RNum
Can't get RCore from RAsm's RNum
Can't get RCore from RAsm's RNum
Can't get RCore from RAsm's RNum
Process 15894 exited with status = 0 (0x00000000)
(lldb) q
$
```

**Test plan**

See above

**Closing issues**

null deref