### PR TITLE
Fix tests to use `rizin =` instead of `rizin -`

### DIFF
--- a/test/db/extras/analysis_ghidra
+++ b/test/db/extras/analysis_ghidra
@@ -197,7 +197,7 @@ EOF
 RUN
 
 NAME=v850cmp
-FILE=-
+FILE==
 EXPECT=<<EOF
 ghidra
 V850:LE:32:default
@@ -233,7 +233,7 @@ EOF
 RUN
 
 NAME=v850load
-FILE=-
+FILE==
 EXPECT=<<EOF
 ghidra
 V850:LE:32:default

--- a/test/db/extras/asm_ghidra
+++ b/test/db/extras/asm_ghidra
@@ -698,7 +698,7 @@ EOF
 RUN
 
 NAME=rz-asm
-FILE=-
+FILE==
 CMDS=<<EOF
 !rz-asm -a ghidra -c x86:LE:32:default:gcc -d 89e1909090909090909090909090
 EOF
@@ -720,7 +720,7 @@ EOF
 RUN
 
 NAME=asm.cpu short
-FILE=-
+FILE==
 CMDS=<<EOF
 e asm.arch=ghidra
 e asm.cpu=v850
@@ -745,7 +745,7 @@ EOF
 RUN
 
 NAME=rz-asm short
-FILE=-
+FILE==
 CMDS=<<EOF
 rz-asm -a ghidra -c v850 -b 32 -d 8100e009
 EOF

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -2717,7 +2717,7 @@ EOF
 RUN
 
 NAME=pdgs
-FILE=-
+FILE==
 EXPECT=<<EOF
 6502:BE:16:default
 6502:LE:16:default


### PR DESCRIPTION
Because after 0.2.[01] version Rizin swapped `-` and `=`, where `-` now reads from stdin.
Thus all `FILE=-` should have been replaced with `FILE==`.