### PR TITLE
Support Callables and Atomic Types (Fix #49)

### DIFF
--- a/src/RizinTypeFactory.h
+++ b/src/RizinTypeFactory.h
@@ -23,6 +23,7 @@ class RizinTypeFactory : public TypeFactory
 		Datatype *addRizinStruct(RzBaseType *type, StackTypes &stack_types, bool prototype);
 		Datatype *addRizinEnum(RzBaseType *type);
 		Datatype *addRizinTypedef(RzBaseType *type, StackTypes &stack_types);
+		Datatype *addRizinAtomicType(RzBaseType *type, StackTypes &stack_types);
 		Datatype *queryRizin(const string &n, StackTypes &stack_types, bool prototype);
 
 	protected:

--- a/src/RizinUtils.h
+++ b/src/RizinUtils.h
@@ -35,4 +35,15 @@ template<typename T, typename F> void rz_vector_foreach_cpp(RzVector *vec, const
 	}
 }
 
+template<typename T, typename F> bool rz_pvector_foreach_cpp(RzPVector *vec, const F &func)
+{
+	void **it;
+	rz_pvector_foreach(vec, it)
+	{
+		if(!func(reinterpret_cast<T *>(*it)))
+			return false;
+	}
+	return true;
+}
+
 #endif //RZ_GHIDRA_RIZINUTILS_H

--- a/test/bins/jni-simplified.h
+++ b/test/bins/jni-simplified.h
@@ -1,0 +1,466 @@
+typedef __builtin_va_list __gnuc_va_list;
+typedef __gnuc_va_list va_list;
+typedef unsigned char jboolean;
+typedef char jbyte;
+typedef unsigned short jchar;
+typedef short jshort;
+typedef int jint;
+typedef long long jlong;
+typedef float jfloat;
+typedef double jdouble;
+
+
+
+typedef jint jsize;
+typedef void* jobject;
+typedef jobject jclass;
+typedef jobject jstring;
+typedef jobject jarray;
+typedef jarray jobjectArray;
+typedef jarray jbooleanArray;
+typedef jarray jbyteArray;
+typedef jarray jcharArray;
+typedef jarray jshortArray;
+typedef jarray jintArray;
+typedef jarray jlongArray;
+typedef jarray jfloatArray;
+typedef jarray jdoubleArray;
+typedef jobject jthrowable;
+typedef jobject jweak;
+
+
+
+struct _jfieldID {};
+typedef struct _jfieldID* jfieldID;
+
+struct _jmethodID {};
+typedef struct _jmethodID* jmethodID;
+
+struct JNIInvokeInterface;
+
+typedef struct {
+    jobject l;
+} jvalue;
+
+typedef enum {
+    JNIInvalidRefType = 0,
+    JNILocalRefType = 1,
+    JNIGlobalRefType = 2,
+    JNIWeakGlobalRefType = 3
+} jobjectRefType;
+
+typedef struct {
+    const char* name;
+    const char* signature;
+    void* fnPtr;
+} JNINativeMethod;
+
+struct _JNIEnv;
+struct _JavaVM;
+typedef const struct JNINativeInterface* C_JNIEnv;
+
+
+
+
+
+typedef const struct JNINativeInterface* JNIEnv;
+typedef const struct JNIInvokeInterface* JavaVM;
+
+
+
+
+
+struct JNINativeInterface {
+    void* reserved0;
+    void* reserved1;
+    void* reserved2;
+    void* reserved3;
+
+    jint (*GetVersion)(JNIEnv *);
+
+    jclass (*DefineClass)(JNIEnv*, const char*, jobject, const jbyte*,
+                        jsize);
+    jclass (*FindClass)(JNIEnv*, const char*);
+
+    jmethodID (*FromReflectedMethod)(JNIEnv*, jobject);
+    jfieldID (*FromReflectedField)(JNIEnv*, jobject);
+
+    jobject (*ToReflectedMethod)(JNIEnv*, jclass, jmethodID, jboolean);
+
+    jclass (*GetSuperclass)(JNIEnv*, jclass);
+    jboolean (*IsAssignableFrom)(JNIEnv*, jclass, jclass);
+
+
+    jobject (*ToReflectedField)(JNIEnv*, jclass, jfieldID, jboolean);
+
+    jint (*Throw)(JNIEnv*, jthrowable);
+    jint (*ThrowNew)(JNIEnv *, jclass, const char *);
+    jthrowable (*ExceptionOccurred)(JNIEnv*);
+    void (*ExceptionDescribe)(JNIEnv*);
+    void (*ExceptionClear)(JNIEnv*);
+    void (*FatalError)(JNIEnv*, const char*);
+
+    jint (*PushLocalFrame)(JNIEnv*, jint);
+    jobject (*PopLocalFrame)(JNIEnv*, jobject);
+
+    jobject (*NewGlobalRef)(JNIEnv*, jobject);
+    void (*DeleteGlobalRef)(JNIEnv*, jobject);
+    void (*DeleteLocalRef)(JNIEnv*, jobject);
+    jboolean (*IsSameObject)(JNIEnv*, jobject, jobject);
+
+    jobject (*NewLocalRef)(JNIEnv*, jobject);
+    jint (*EnsureLocalCapacity)(JNIEnv*, jint);
+
+    jobject (*AllocObject)(JNIEnv*, jclass);
+    jobject (*NewObject)(JNIEnv*, jclass, jmethodID, ...);
+    jobject (*NewObjectV)(JNIEnv*, jclass, jmethodID, va_list);
+    jobject (*NewObjectA)(JNIEnv*, jclass, jmethodID, jvalue*);
+
+    jclass (*GetObjectClass)(JNIEnv*, jobject);
+    jboolean (*IsInstanceOf)(JNIEnv*, jobject, jclass);
+    jmethodID (*GetMethodID)(JNIEnv*, jclass, const char*, const char*);
+
+    jobject (*CallObjectMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jobject (*CallObjectMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jobject (*CallObjectMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jboolean (*CallBooleanMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jboolean (*CallBooleanMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jboolean (*CallBooleanMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jbyte (*CallByteMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jbyte (*CallByteMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jbyte (*CallByteMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jchar (*CallCharMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jchar (*CallCharMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jchar (*CallCharMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jshort (*CallShortMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jshort (*CallShortMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jshort (*CallShortMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jint (*CallIntMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jint (*CallIntMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jint (*CallIntMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jlong (*CallLongMethod)(JNIEnv*, jobject, jmethodID, ...);
+    jlong (*CallLongMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    jlong (*CallLongMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+    jfloat (*CallFloatMethod)(JNIEnv*, jobject, jmethodID, ...) ;
+    jfloat (*CallFloatMethodV)(JNIEnv*, jobject, jmethodID, va_list) ;
+    jfloat (*CallFloatMethodA)(JNIEnv*, jobject, jmethodID, jvalue*) ;
+    jdouble (*CallDoubleMethod)(JNIEnv*, jobject, jmethodID, ...) ;
+    jdouble (*CallDoubleMethodV)(JNIEnv*, jobject, jmethodID, va_list) ;
+    jdouble (*CallDoubleMethodA)(JNIEnv*, jobject, jmethodID, jvalue*) ;
+    void (*CallVoidMethod)(JNIEnv*, jobject, jmethodID, ...);
+    void (*CallVoidMethodV)(JNIEnv*, jobject, jmethodID, va_list);
+    void (*CallVoidMethodA)(JNIEnv*, jobject, jmethodID, jvalue*);
+
+    jobject (*CallNonvirtualObjectMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jobject (*CallNonvirtualObjectMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    jobject (*CallNonvirtualObjectMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+    jboolean (*CallNonvirtualBooleanMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jboolean (*CallNonvirtualBooleanMethodV)(JNIEnv*, jobject, jclass,
+                         jmethodID, va_list);
+    jboolean (*CallNonvirtualBooleanMethodA)(JNIEnv*, jobject, jclass,
+                         jmethodID, jvalue*);
+    jbyte (*CallNonvirtualByteMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jbyte (*CallNonvirtualByteMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    jbyte (*CallNonvirtualByteMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+    jchar (*CallNonvirtualCharMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jchar (*CallNonvirtualCharMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    jchar (*CallNonvirtualCharMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+    jshort (*CallNonvirtualShortMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jshort (*CallNonvirtualShortMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    jshort (*CallNonvirtualShortMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+    jint (*CallNonvirtualIntMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jint (*CallNonvirtualIntMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    jint (*CallNonvirtualIntMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+    jlong (*CallNonvirtualLongMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    jlong (*CallNonvirtualLongMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    jlong (*CallNonvirtualLongMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+    jfloat (*CallNonvirtualFloatMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...) ;
+    jfloat (*CallNonvirtualFloatMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list) ;
+    jfloat (*CallNonvirtualFloatMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*) ;
+    jdouble (*CallNonvirtualDoubleMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...) ;
+    jdouble (*CallNonvirtualDoubleMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list) ;
+    jdouble (*CallNonvirtualDoubleMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*) ;
+    void (*CallNonvirtualVoidMethod)(JNIEnv*, jobject, jclass,
+                        jmethodID, ...);
+    void (*CallNonvirtualVoidMethodV)(JNIEnv*, jobject, jclass,
+                        jmethodID, va_list);
+    void (*CallNonvirtualVoidMethodA)(JNIEnv*, jobject, jclass,
+                        jmethodID, jvalue*);
+
+    jfieldID (*GetFieldID)(JNIEnv*, jclass, const char*, const char*);
+
+    jobject (*GetObjectField)(JNIEnv*, jobject, jfieldID);
+    jboolean (*GetBooleanField)(JNIEnv*, jobject, jfieldID);
+    jbyte (*GetByteField)(JNIEnv*, jobject, jfieldID);
+    jchar (*GetCharField)(JNIEnv*, jobject, jfieldID);
+    jshort (*GetShortField)(JNIEnv*, jobject, jfieldID);
+    jint (*GetIntField)(JNIEnv*, jobject, jfieldID);
+    jlong (*GetLongField)(JNIEnv*, jobject, jfieldID);
+    jfloat (*GetFloatField)(JNIEnv*, jobject, jfieldID) ;
+    jdouble (*GetDoubleField)(JNIEnv*, jobject, jfieldID) ;
+
+    void (*SetObjectField)(JNIEnv*, jobject, jfieldID, jobject);
+    void (*SetBooleanField)(JNIEnv*, jobject, jfieldID, jboolean);
+    void (*SetByteField)(JNIEnv*, jobject, jfieldID, jbyte);
+    void (*SetCharField)(JNIEnv*, jobject, jfieldID, jchar);
+    void (*SetShortField)(JNIEnv*, jobject, jfieldID, jshort);
+    void (*SetIntField)(JNIEnv*, jobject, jfieldID, jint);
+    void (*SetLongField)(JNIEnv*, jobject, jfieldID, jlong);
+    void (*SetFloatField)(JNIEnv*, jobject, jfieldID, jfloat) ;
+    void (*SetDoubleField)(JNIEnv*, jobject, jfieldID, jdouble) ;
+
+    jmethodID (*GetStaticMethodID)(JNIEnv*, jclass, const char*, const char*);
+
+    jobject (*CallStaticObjectMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jobject (*CallStaticObjectMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    jobject (*CallStaticObjectMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+    jboolean (*CallStaticBooleanMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jboolean (*CallStaticBooleanMethodV)(JNIEnv*, jclass, jmethodID,
+                        va_list);
+    jboolean (*CallStaticBooleanMethodA)(JNIEnv*, jclass, jmethodID,
+                        jvalue*);
+    jbyte (*CallStaticByteMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jbyte (*CallStaticByteMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    jbyte (*CallStaticByteMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+    jchar (*CallStaticCharMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jchar (*CallStaticCharMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    jchar (*CallStaticCharMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+    jshort (*CallStaticShortMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jshort (*CallStaticShortMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    jshort (*CallStaticShortMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+    jint (*CallStaticIntMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jint (*CallStaticIntMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    jint (*CallStaticIntMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+    jlong (*CallStaticLongMethod)(JNIEnv*, jclass, jmethodID, ...);
+    jlong (*CallStaticLongMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    jlong (*CallStaticLongMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+    jfloat (*CallStaticFloatMethod)(JNIEnv*, jclass, jmethodID, ...) ;
+    jfloat (*CallStaticFloatMethodV)(JNIEnv*, jclass, jmethodID, va_list) ;
+    jfloat (*CallStaticFloatMethodA)(JNIEnv*, jclass, jmethodID, jvalue*) ;
+    jdouble (*CallStaticDoubleMethod)(JNIEnv*, jclass, jmethodID, ...) ;
+    jdouble (*CallStaticDoubleMethodV)(JNIEnv*, jclass, jmethodID, va_list) ;
+    jdouble (*CallStaticDoubleMethodA)(JNIEnv*, jclass, jmethodID, jvalue*) ;
+    void (*CallStaticVoidMethod)(JNIEnv*, jclass, jmethodID, ...);
+    void (*CallStaticVoidMethodV)(JNIEnv*, jclass, jmethodID, va_list);
+    void (*CallStaticVoidMethodA)(JNIEnv*, jclass, jmethodID, jvalue*);
+
+    jfieldID (*GetStaticFieldID)(JNIEnv*, jclass, const char*,
+                        const char*);
+
+    jobject (*GetStaticObjectField)(JNIEnv*, jclass, jfieldID);
+    jboolean (*GetStaticBooleanField)(JNIEnv*, jclass, jfieldID);
+    jbyte (*GetStaticByteField)(JNIEnv*, jclass, jfieldID);
+    jchar (*GetStaticCharField)(JNIEnv*, jclass, jfieldID);
+    jshort (*GetStaticShortField)(JNIEnv*, jclass, jfieldID);
+    jint (*GetStaticIntField)(JNIEnv*, jclass, jfieldID);
+    jlong (*GetStaticLongField)(JNIEnv*, jclass, jfieldID);
+    jfloat (*GetStaticFloatField)(JNIEnv*, jclass, jfieldID) ;
+    jdouble (*GetStaticDoubleField)(JNIEnv*, jclass, jfieldID) ;
+
+    void (*SetStaticObjectField)(JNIEnv*, jclass, jfieldID, jobject);
+    void (*SetStaticBooleanField)(JNIEnv*, jclass, jfieldID, jboolean);
+    void (*SetStaticByteField)(JNIEnv*, jclass, jfieldID, jbyte);
+    void (*SetStaticCharField)(JNIEnv*, jclass, jfieldID, jchar);
+    void (*SetStaticShortField)(JNIEnv*, jclass, jfieldID, jshort);
+    void (*SetStaticIntField)(JNIEnv*, jclass, jfieldID, jint);
+    void (*SetStaticLongField)(JNIEnv*, jclass, jfieldID, jlong);
+    void (*SetStaticFloatField)(JNIEnv*, jclass, jfieldID, jfloat) ;
+    void (*SetStaticDoubleField)(JNIEnv*, jclass, jfieldID, jdouble) ;
+
+    jstring (*NewString)(JNIEnv*, const jchar*, jsize);
+    jsize (*GetStringLength)(JNIEnv*, jstring);
+    const jchar* (*GetStringChars)(JNIEnv*, jstring, jboolean*);
+    void (*ReleaseStringChars)(JNIEnv*, jstring, const jchar*);
+    jstring (*NewStringUTF)(JNIEnv*, const char*);
+    jsize (*GetStringUTFLength)(JNIEnv*, jstring);
+
+    const char* (*GetStringUTFChars)(JNIEnv*, jstring, jboolean*);
+    void (*ReleaseStringUTFChars)(JNIEnv*, jstring, const char*);
+    jsize (*GetArrayLength)(JNIEnv*, jarray);
+    jobjectArray (*NewObjectArray)(JNIEnv*, jsize, jclass, jobject);
+    jobject (*GetObjectArrayElement)(JNIEnv*, jobjectArray, jsize);
+    void (*SetObjectArrayElement)(JNIEnv*, jobjectArray, jsize, jobject);
+
+    jbooleanArray (*NewBooleanArray)(JNIEnv*, jsize);
+    jbyteArray (*NewByteArray)(JNIEnv*, jsize);
+    jcharArray (*NewCharArray)(JNIEnv*, jsize);
+    jshortArray (*NewShortArray)(JNIEnv*, jsize);
+    jintArray (*NewIntArray)(JNIEnv*, jsize);
+    jlongArray (*NewLongArray)(JNIEnv*, jsize);
+    jfloatArray (*NewFloatArray)(JNIEnv*, jsize);
+    jdoubleArray (*NewDoubleArray)(JNIEnv*, jsize);
+
+    jboolean* (*GetBooleanArrayElements)(JNIEnv*, jbooleanArray, jboolean*);
+    jbyte* (*GetByteArrayElements)(JNIEnv*, jbyteArray, jboolean*);
+    jchar* (*GetCharArrayElements)(JNIEnv*, jcharArray, jboolean*);
+    jshort* (*GetShortArrayElements)(JNIEnv*, jshortArray, jboolean*);
+    jint* (*GetIntArrayElements)(JNIEnv*, jintArray, jboolean*);
+    jlong* (*GetLongArrayElements)(JNIEnv*, jlongArray, jboolean*);
+    jfloat* (*GetFloatArrayElements)(JNIEnv*, jfloatArray, jboolean*);
+    jdouble* (*GetDoubleArrayElements)(JNIEnv*, jdoubleArray, jboolean*);
+
+    void (*ReleaseBooleanArrayElements)(JNIEnv*, jbooleanArray,
+                        jboolean*, jint);
+    void (*ReleaseByteArrayElements)(JNIEnv*, jbyteArray,
+                        jbyte*, jint);
+    void (*ReleaseCharArrayElements)(JNIEnv*, jcharArray,
+                        jchar*, jint);
+    void (*ReleaseShortArrayElements)(JNIEnv*, jshortArray,
+                        jshort*, jint);
+    void (*ReleaseIntArrayElements)(JNIEnv*, jintArray,
+                        jint*, jint);
+    void (*ReleaseLongArrayElements)(JNIEnv*, jlongArray,
+                        jlong*, jint);
+    void (*ReleaseFloatArrayElements)(JNIEnv*, jfloatArray,
+                        jfloat*, jint);
+    void (*ReleaseDoubleArrayElements)(JNIEnv*, jdoubleArray,
+                        jdouble*, jint);
+
+    void (*GetBooleanArrayRegion)(JNIEnv*, jbooleanArray,
+                        jsize, jsize, jboolean*);
+    void (*GetByteArrayRegion)(JNIEnv*, jbyteArray,
+                        jsize, jsize, jbyte*);
+    void (*GetCharArrayRegion)(JNIEnv*, jcharArray,
+                        jsize, jsize, jchar*);
+    void (*GetShortArrayRegion)(JNIEnv*, jshortArray,
+                        jsize, jsize, jshort*);
+    void (*GetIntArrayRegion)(JNIEnv*, jintArray,
+                        jsize, jsize, jint*);
+    void (*GetLongArrayRegion)(JNIEnv*, jlongArray,
+                        jsize, jsize, jlong*);
+    void (*GetFloatArrayRegion)(JNIEnv*, jfloatArray,
+                        jsize, jsize, jfloat*);
+    void (*GetDoubleArrayRegion)(JNIEnv*, jdoubleArray,
+                        jsize, jsize, jdouble*);
+
+
+    void (*SetBooleanArrayRegion)(JNIEnv*, jbooleanArray,
+                        jsize, jsize, const jboolean*);
+    void (*SetByteArrayRegion)(JNIEnv*, jbyteArray,
+                        jsize, jsize, const jbyte*);
+    void (*SetCharArrayRegion)(JNIEnv*, jcharArray,
+                        jsize, jsize, const jchar*);
+    void (*SetShortArrayRegion)(JNIEnv*, jshortArray,
+                        jsize, jsize, const jshort*);
+    void (*SetIntArrayRegion)(JNIEnv*, jintArray,
+                        jsize, jsize, const jint*);
+    void (*SetLongArrayRegion)(JNIEnv*, jlongArray,
+                        jsize, jsize, const jlong*);
+    void (*SetFloatArrayRegion)(JNIEnv*, jfloatArray,
+                        jsize, jsize, const jfloat*);
+    void (*SetDoubleArrayRegion)(JNIEnv*, jdoubleArray,
+                        jsize, jsize, const jdouble*);
+
+    jint (*RegisterNatives)(JNIEnv*, jclass, const JNINativeMethod*,
+                        jint);
+    jint (*UnregisterNatives)(JNIEnv*, jclass);
+    jint (*MonitorEnter)(JNIEnv*, jobject);
+    jint (*MonitorExit)(JNIEnv*, jobject);
+    jint (*GetJavaVM)(JNIEnv*, JavaVM**);
+
+    void (*GetStringRegion)(JNIEnv*, jstring, jsize, jsize, jchar*);
+    void (*GetStringUTFRegion)(JNIEnv*, jstring, jsize, jsize, char*);
+
+    void* (*GetPrimitiveArrayCritical)(JNIEnv*, jarray, jboolean*);
+    void (*ReleasePrimitiveArrayCritical)(JNIEnv*, jarray, void*, jint);
+
+    const jchar* (*GetStringCritical)(JNIEnv*, jstring, jboolean*);
+    void (*ReleaseStringCritical)(JNIEnv*, jstring, const jchar*);
+
+    jweak (*NewWeakGlobalRef)(JNIEnv*, jobject);
+    void (*DeleteWeakGlobalRef)(JNIEnv*, jweak);
+
+    jboolean (*ExceptionCheck)(JNIEnv*);
+
+    jobject (*NewDirectByteBuffer)(JNIEnv*, void*, jlong);
+    void* (*GetDirectBufferAddress)(JNIEnv*, jobject);
+    jlong (*GetDirectBufferCapacity)(JNIEnv*, jobject);
+
+
+    jobjectRefType (*GetObjectRefType)(JNIEnv*, jobject);
+};
+
+
+
+
+
+
+
+struct _JNIEnv {
+
+    const struct JNINativeInterface* functions;
+};
+
+
+
+
+
+struct JNIInvokeInterface {
+    void* reserved0;
+    void* reserved1;
+    void* reserved2;
+
+    jint (*DestroyJavaVM)(JavaVM*);
+    jint (*AttachCurrentThread)(JavaVM*, JNIEnv**, void*);
+    jint (*DetachCurrentThread)(JavaVM*);
+    jint (*GetEnv)(JavaVM*, void**, jint);
+    jint (*AttachCurrentThreadAsDaemon)(JavaVM*, JNIEnv**, void*);
+};
+
+
+
+
+struct _JavaVM {
+    const struct JNIInvokeInterface* functions;
+};
+
+struct _JavaVMAttachArgs {
+    jint version;
+    const char* name;
+    jobject group;
+};
+typedef struct _JavaVMAttachArgs JavaVMAttachArgs;
+
+
+
+
+
+typedef struct _JavaVMOption {
+    const char* optionString;
+    void* extraInfo;
+} JavaVMOption;
+
+typedef struct _JavaVMInitArgs {
+    jint version;
+
+    jint nOptions;
+    JavaVMOption* options;
+    jboolean ignoreUnrecognized;
+} JavaVMInitArgs;
+__attribute__ ((visibility ("default"))) jint JNI_OnLoad(JavaVM* vm, void* reserved);
+__attribute__ ((visibility ("default"))) void JNI_OnUnload(JavaVM* vm, void* reserved);

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -285,7 +285,7 @@ NAME=function variable annotations
 FILE=bins/dectest64
 EXPECT=<<EOF
 {
-  "code": "\n// WARNING: Could not reconcile some variable overlaps\n// WARNING: [rz-ghidra] Failed to match type int for variable argc to Decompiler type: Unknown type identifier int\n// WARNING: [rz-ghidra] Detected overlap for variable var_20h\n// WARNING: [rz-ghidra] Detected overlap for variable var_ch\n\nundefined8 main(undefined8 argc, char **argv)\n{\n    undefined8 uVar1;\n    int64_t in_FS_OFFSET;\n    int64_t var_30h;\n    int64_t var_24h;\n    int64_t var_8h;\n    \n    var_8h = *(int64_t *)(in_FS_OFFSET + 0x28);\n    var_24h._0_4_ = (undefined4)argc;\n    sym.Aeropause((int64_t)&var_24h + 4, (undefined4)argc, argv);\n    uVar1 = 0;\n    if (var_8h != *(int64_t *)(in_FS_OFFSET + 0x28)) {\n        uVar1 = sym.imp.__stack_chk_fail();\n    }\n    return uVar1;\n}\n",
+  "code": "\n// WARNING: Could not reconcile some variable overlaps\n// WARNING: [rz-ghidra] Detected overlap for variable var_20h\n// WARNING: [rz-ghidra] Detected overlap for variable var_ch\n\nundefined8 main(int argc, char **argv)\n{\n    undefined8 uVar1;\n    int64_t in_FS_OFFSET;\n    int64_t var_30h;\n    int64_t var_24h;\n    int64_t var_8h;\n    \n    var_8h = *(int64_t *)(in_FS_OFFSET + 0x28);\n    var_24h._0_4_ = argc;\n    sym.Aeropause((int64_t)&var_24h + 4, argc, argv);\n    uVar1 = 0;\n    if (var_8h != *(int64_t *)(in_FS_OFFSET + 0x28)) {\n        uVar1 = sym.imp.__stack_chk_fail();\n    }\n    return uVar1;\n}\n",
   "annotations": [
     {
       "start": 1,
@@ -421,886 +421,658 @@ EXPECT=<<EOF
     },
     {
       "start": 80,
-      "end": 86,
+      "end": 88,
       "type": "offset",
       "offset": 4198782
     },
     {
       "start": 80,
-      "end": 86,
+      "end": 88,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 87,
-      "end": 89,
+      "start": 89,
+      "end": 96,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 87,
-      "end": 89,
+      "start": 89,
+      "end": 96,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 90,
-      "end": 95,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 90,
-      "end": 95,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 96,
+      "start": 97,
       "end": 100,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 96,
+      "start": 97,
       "end": 100,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
       "start": 101,
-      "end": 104,
+      "end": 109,
       "type": "offset",
       "offset": 4198782
     },
     {
       "start": 101,
-      "end": 104,
+      "end": 109,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 105,
-      "end": 108,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 105,
-      "end": 108,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 109,
+      "start": 110,
       "end": 117,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 109,
+      "start": 110,
       "end": 117,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
       "start": 118,
-      "end": 122,
+      "end": 121,
       "type": "offset",
       "offset": 4198782
     },
     {
       "start": 118,
-      "end": 122,
+      "end": 121,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 123,
-      "end": 125,
+      "start": 121,
+      "end": 129,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 123,
-      "end": 125,
+      "start": 121,
+      "end": 129,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 126,
-      "end": 136,
+      "start": 130,
+      "end": 141,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 126,
-      "end": 136,
+      "start": 130,
+      "end": 141,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 137,
-      "end": 142,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 137,
-      "end": 142,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 143,
+      "start": 142,
       "end": 150,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 143,
+      "start": 142,
       "end": 150,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
       "start": 151,
-      "end": 155,
+      "end": 158,
       "type": "offset",
       "offset": 4198782
     },
     {
       "start": 151,
-      "end": 155,
+      "end": 158,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 156,
-      "end": 166,
+      "start": 159,
+      "end": 162,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 156,
-      "end": 166,
+      "start": 159,
+      "end": 162,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 167,
-      "end": 170,
+      "start": 163,
+      "end": 171,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 167,
-      "end": 170,
+      "start": 163,
+      "end": 171,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 171,
-      "end": 174,
+      "start": 172,
+      "end": 178,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 171,
-      "end": 174,
+      "start": 172,
+      "end": 178,
       "type": "syntax_highlight",
       "syntax_highlight": "comment"
     },
     {
-      "start": 174,
-      "end": 182,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 174,
-      "end": 182,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 183,
-      "end": 194,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 183,
-      "end": 194,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 195,
-      "end": 203,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 195,
-      "end": 203,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 204,
-      "end": 211,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 204,
-      "end": 211,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 212,
-      "end": 215,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 212,
-      "end": 215,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 216,
-      "end": 224,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 216,
-      "end": 224,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 225,
-      "end": 232,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 225,
-      "end": 232,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 233,
-      "end": 236,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 233,
-      "end": 236,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 236,
-      "end": 244,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 236,
-      "end": 244,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 245,
-      "end": 256,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 245,
-      "end": 256,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 257,
-      "end": 265,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 257,
-      "end": 265,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 266,
-      "end": 273,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 266,
-      "end": 273,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 274,
-      "end": 277,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 274,
-      "end": 277,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 278,
-      "end": 286,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 278,
-      "end": 286,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 287,
-      "end": 293,
-      "type": "offset",
-      "offset": 4198782
-    },
-    {
-      "start": 287,
-      "end": 293,
-      "type": "syntax_highlight",
-      "syntax_highlight": "comment"
-    },
-    {
-      "start": 295,
-      "end": 305,
+      "start": 180,
+      "end": 190,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 306,
-      "end": 310,
+      "start": 191,
+      "end": 195,
       "type": "function_name",
       "name": "main",
       "offset": 4198782
     },
     {
-      "start": 306,
-      "end": 310,
+      "start": 191,
+      "end": 195,
       "type": "offset",
       "offset": 4198782
     },
     {
-      "start": 306,
-      "end": 310,
+      "start": 191,
+      "end": 195,
       "type": "syntax_highlight",
       "syntax_highlight": "function_name"
     },
     {
-      "start": 311,
-      "end": 321,
+      "start": 196,
+      "end": 199,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 322,
-      "end": 326,
+      "start": 200,
+      "end": 204,
       "type": "function_parameter",
       "name": "argc"
     },
     {
-      "start": 322,
-      "end": 326,
+      "start": 200,
+      "end": 204,
       "type": "syntax_highlight",
       "syntax_highlight": "function_parameter"
     },
     {
-      "start": 328,
-      "end": 332,
+      "start": 206,
+      "end": 210,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 335,
-      "end": 339,
+      "start": 213,
+      "end": 217,
       "type": "function_parameter",
       "name": "argv"
     },
     {
-      "start": 335,
-      "end": 339,
+      "start": 213,
+      "end": 217,
       "type": "syntax_highlight",
       "syntax_highlight": "function_parameter"
     },
     {
-      "start": 347,
-      "end": 357,
+      "start": 225,
+      "end": 235,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 358,
-      "end": 363,
+      "start": 236,
+      "end": 241,
       "type": "local_variable",
       "name": "uVar1"
     },
     {
-      "start": 358,
-      "end": 363,
+      "start": 236,
+      "end": 241,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 369,
-      "end": 376,
+      "start": 247,
+      "end": 254,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 377,
-      "end": 389,
+      "start": 255,
+      "end": 267,
       "type": "local_variable",
       "name": "in_FS_OFFSET"
     },
     {
+      "start": 255,
+      "end": 267,
+      "type": "syntax_highlight",
+      "syntax_highlight": "local_variable"
+    },
+    {
+      "start": 273,
+      "end": 280,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 281,
+      "end": 288,
+      "type": "local_variable",
+      "name": "var_30h"
+    },
+    {
+      "start": 281,
+      "end": 288,
+      "type": "syntax_highlight",
+      "syntax_highlight": "local_variable"
+    },
+    {
+      "start": 294,
+      "end": 301,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 302,
+      "end": 309,
+      "type": "local_variable",
+      "name": "var_24h"
+    },
+    {
+      "start": 302,
+      "end": 309,
+      "type": "syntax_highlight",
+      "syntax_highlight": "local_variable"
+    },
+    {
+      "start": 315,
+      "end": 322,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 323,
+      "end": 329,
+      "type": "local_variable",
+      "name": "var_8h"
+    },
+    {
+      "start": 323,
+      "end": 329,
+      "type": "syntax_highlight",
+      "syntax_highlight": "local_variable"
+    },
+    {
+      "start": 340,
+      "end": 346,
+      "type": "local_variable",
+      "name": "var_8h"
+    },
+    {
+      "start": 340,
+      "end": 346,
+      "type": "syntax_highlight",
+      "syntax_highlight": "local_variable"
+    },
+    {
+      "start": 347,
+      "end": 348,
+      "type": "offset",
+      "offset": 4198797
+    },
+    {
+      "start": 349,
+      "end": 350,
+      "type": "offset",
+      "offset": 4198797
+    },
+    {
+      "start": 351,
+      "end": 358,
+      "type": "syntax_highlight",
+      "syntax_highlight": "datatype"
+    },
+    {
+      "start": 362,
+      "end": 374,
+      "type": "local_variable",
+      "name": "in_FS_OFFSET"
+    },
+    {
+      "start": 362,
+      "end": 374,
+      "type": "syntax_highlight",
+      "syntax_highlight": "local_variable"
+    },
+    {
+      "start": 375,
+      "end": 376,
+      "type": "offset",
+      "offset": 4198797
+    },
+    {
       "start": 377,
-      "end": 389,
+      "end": 381,
+      "type": "syntax_highlight",
+      "syntax_highlight": "constant_variable"
+    },
+    {
+      "start": 340,
+      "end": 382,
+      "type": "offset",
+      "offset": 4198797
+    },
+    {
+      "start": 388,
+      "end": 395,
+      "type": "local_variable",
+      "name": "var_24h"
+    },
+    {
+      "start": 388,
+      "end": 395,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
       "start": 395,
-      "end": 402,
-      "type": "syntax_highlight",
-      "syntax_highlight": "datatype"
-    },
-    {
-      "start": 403,
-      "end": 410,
-      "type": "local_variable",
-      "name": "var_30h"
-    },
-    {
-      "start": 403,
-      "end": 410,
-      "type": "syntax_highlight",
-      "syntax_highlight": "local_variable"
-    },
-    {
-      "start": 416,
-      "end": 423,
-      "type": "syntax_highlight",
-      "syntax_highlight": "datatype"
-    },
-    {
-      "start": 424,
-      "end": 431,
-      "type": "local_variable",
-      "name": "var_24h"
-    },
-    {
-      "start": 424,
-      "end": 431,
-      "type": "syntax_highlight",
-      "syntax_highlight": "local_variable"
-    },
-    {
-      "start": 437,
-      "end": 444,
-      "type": "syntax_highlight",
-      "syntax_highlight": "datatype"
-    },
-    {
-      "start": 445,
-      "end": 451,
-      "type": "local_variable",
-      "name": "var_8h"
-    },
-    {
-      "start": 445,
-      "end": 451,
-      "type": "syntax_highlight",
-      "syntax_highlight": "local_variable"
-    },
-    {
-      "start": 462,
-      "end": 468,
-      "type": "local_variable",
-      "name": "var_8h"
-    },
-    {
-      "start": 462,
-      "end": 468,
-      "type": "syntax_highlight",
-      "syntax_highlight": "local_variable"
-    },
-    {
-      "start": 469,
-      "end": 470,
-      "type": "offset",
-      "offset": 4198797
-    },
-    {
-      "start": 471,
-      "end": 472,
-      "type": "offset",
-      "offset": 4198797
-    },
-    {
-      "start": 473,
-      "end": 480,
-      "type": "syntax_highlight",
-      "syntax_highlight": "datatype"
-    },
-    {
-      "start": 484,
-      "end": 496,
-      "type": "local_variable",
-      "name": "in_FS_OFFSET"
-    },
-    {
-      "start": 484,
-      "end": 496,
-      "type": "syntax_highlight",
-      "syntax_highlight": "local_variable"
-    },
-    {
-      "start": 497,
-      "end": 498,
-      "type": "offset",
-      "offset": 4198797
-    },
-    {
-      "start": 499,
-      "end": 503,
-      "type": "syntax_highlight",
-      "syntax_highlight": "constant_variable"
-    },
-    {
-      "start": 462,
-      "end": 504,
-      "type": "offset",
-      "offset": 4198797
-    },
-    {
-      "start": 510,
-      "end": 517,
-      "type": "local_variable",
-      "name": "var_24h"
-    },
-    {
-      "start": 510,
-      "end": 517,
-      "type": "syntax_highlight",
-      "syntax_highlight": "local_variable"
-    },
-    {
-      "start": 517,
-      "end": 518,
+      "end": 396,
       "type": "offset",
       "offset": 4198828
     },
     {
-      "start": 524,
-      "end": 525,
+      "start": 402,
+      "end": 403,
       "type": "offset",
       "offset": 4198828
     },
     {
-      "start": 527,
-      "end": 537,
-      "type": "syntax_highlight",
-      "syntax_highlight": "datatype"
-    },
-    {
-      "start": 538,
-      "end": 542,
+      "start": 404,
+      "end": 408,
       "type": "function_parameter",
       "name": "argc"
     },
     {
-      "start": 538,
-      "end": 542,
+      "start": 404,
+      "end": 408,
       "type": "syntax_highlight",
       "syntax_highlight": "function_parameter"
     },
     {
-      "start": 510,
-      "end": 542,
+      "start": 388,
+      "end": 408,
       "type": "offset",
       "offset": 4198828
     },
     {
-      "start": 548,
-      "end": 561,
+      "start": 414,
+      "end": 427,
       "type": "function_name",
       "name": "sym.Aeropause",
       "offset": 4199038
     },
     {
-      "start": 548,
-      "end": 561,
+      "start": 414,
+      "end": 427,
       "type": "syntax_highlight",
       "syntax_highlight": "function_name"
     },
     {
-      "start": 563,
-      "end": 570,
+      "start": 429,
+      "end": 436,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 571,
-      "end": 572,
+      "start": 437,
+      "end": 438,
       "type": "offset",
       "offset": 4198819
     },
     {
-      "start": 572,
-      "end": 579,
+      "start": 438,
+      "end": 445,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 580,
-      "end": 581,
+      "start": 446,
+      "end": 447,
       "type": "offset",
       "offset": 4198819
     },
     {
-      "start": 582,
-      "end": 583,
+      "start": 448,
+      "end": 449,
       "type": "syntax_highlight",
       "syntax_highlight": "constant_variable"
     },
     {
-      "start": 583,
-      "end": 585,
+      "start": 449,
+      "end": 451,
       "type": "offset",
       "offset": 4198828
     },
     {
-      "start": 586,
-      "end": 596,
-      "type": "syntax_highlight",
-      "syntax_highlight": "datatype"
-    },
-    {
-      "start": 597,
-      "end": 601,
+      "start": 451,
+      "end": 455,
       "type": "function_parameter",
       "name": "argc"
     },
     {
-      "start": 597,
-      "end": 601,
+      "start": 451,
+      "end": 455,
       "type": "syntax_highlight",
       "syntax_highlight": "function_parameter"
     },
     {
-      "start": 601,
-      "end": 603,
+      "start": 455,
+      "end": 457,
       "type": "offset",
       "offset": 4198828
     },
     {
-      "start": 603,
-      "end": 607,
+      "start": 457,
+      "end": 461,
       "type": "function_parameter",
       "name": "argv"
     },
     {
-      "start": 603,
-      "end": 607,
+      "start": 457,
+      "end": 461,
       "type": "syntax_highlight",
       "syntax_highlight": "function_parameter"
     },
     {
-      "start": 548,
-      "end": 608,
+      "start": 414,
+      "end": 462,
       "type": "offset",
       "offset": 4198828
     },
     {
-      "start": 614,
-      "end": 619,
+      "start": 468,
+      "end": 473,
       "type": "local_variable",
       "name": "uVar1"
     },
     {
-      "start": 614,
-      "end": 619,
+      "start": 468,
+      "end": 473,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 620,
-      "end": 621,
+      "start": 474,
+      "end": 475,
       "type": "offset",
       "offset": 4198833
     },
     {
-      "start": 622,
-      "end": 623,
+      "start": 476,
+      "end": 477,
       "type": "syntax_highlight",
       "syntax_highlight": "constant_variable"
     },
     {
-      "start": 614,
-      "end": 623,
+      "start": 468,
+      "end": 477,
       "type": "offset",
       "offset": 4198833
     },
     {
-      "start": 629,
-      "end": 631,
+      "start": 483,
+      "end": 485,
       "type": "offset",
       "offset": 4198851
     },
     {
-      "start": 629,
-      "end": 631,
+      "start": 483,
+      "end": 485,
       "type": "syntax_highlight",
       "syntax_highlight": "keyword"
     },
     {
-      "start": 633,
-      "end": 639,
+      "start": 487,
+      "end": 493,
       "type": "local_variable",
       "name": "var_8h"
     },
     {
-      "start": 633,
-      "end": 639,
+      "start": 487,
+      "end": 493,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 640,
-      "end": 642,
+      "start": 494,
+      "end": 496,
       "type": "offset",
       "offset": 4198842
     },
     {
-      "start": 643,
-      "end": 644,
+      "start": 497,
+      "end": 498,
       "type": "offset",
       "offset": 4198842
     },
     {
-      "start": 645,
-      "end": 652,
+      "start": 499,
+      "end": 506,
       "type": "syntax_highlight",
       "syntax_highlight": "datatype"
     },
     {
-      "start": 656,
-      "end": 668,
+      "start": 510,
+      "end": 522,
       "type": "local_variable",
       "name": "in_FS_OFFSET"
     },
     {
-      "start": 656,
-      "end": 668,
+      "start": 510,
+      "end": 522,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 669,
-      "end": 670,
+      "start": 523,
+      "end": 524,
       "type": "offset",
       "offset": 4198842
     },
     {
-      "start": 671,
-      "end": 675,
+      "start": 525,
+      "end": 529,
       "type": "syntax_highlight",
       "syntax_highlight": "constant_variable"
     },
     {
-      "start": 688,
-      "end": 693,
+      "start": 542,
+      "end": 547,
       "type": "local_variable",
       "name": "uVar1"
     },
     {
-      "start": 688,
-      "end": 693,
+      "start": 542,
+      "end": 547,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 694,
-      "end": 695,
+      "start": 548,
+      "end": 549,
       "type": "offset",
       "offset": 4198853
     },
     {
-      "start": 696,
-      "end": 720,
+      "start": 550,
+      "end": 574,
       "type": "function_name",
       "name": "sym.imp.__stack_chk_fail",
       "offset": 4198464
     },
     {
-      "start": 696,
-      "end": 720,
+      "start": 550,
+      "end": 574,
       "type": "syntax_highlight",
       "syntax_highlight": "function_name"
     },
     {
-      "start": 688,
-      "end": 722,
+      "start": 542,
+      "end": 576,
       "type": "offset",
       "offset": 4198853
     },
     {
-      "start": 734,
-      "end": 740,
+      "start": 588,
+      "end": 594,
       "type": "offset",
       "offset": 4198859
     },
     {
-      "start": 734,
-      "end": 740,
+      "start": 588,
+      "end": 594,
       "type": "syntax_highlight",
       "syntax_highlight": "keyword"
     },
     {
-      "start": 741,
-      "end": 746,
+      "start": 595,
+      "end": 600,
       "type": "local_variable",
       "name": "uVar1"
     },
     {
-      "start": 741,
-      "end": 746,
+      "start": 595,
+      "end": 600,
       "type": "syntax_highlight",
       "syntax_highlight": "local_variable"
     },
     {
-      "start": 734,
-      "end": 746,
+      "start": 588,
+      "end": 600,
       "type": "offset",
       "offset": 4198859
     }
@@ -1942,9 +1714,6 @@ NAME=aeropause32 (many features combined)
 FILE=bins/dectest32
 EXPECT=<<EOF
 
-// WARNING: [rz-ghidra] Failed to match type unsigned long for variable arg_8h to Decompiler type: Unknown type
-// identifier unsigned long
-
 void sym.Aeropause(Bright *bright, int32_t argc, char **argv)
 {
     Morning *pMVar1;
@@ -2020,7 +1789,6 @@ FILE=bins/dectest64
 EXPECT=<<EOF
 
 // WARNING: [rz-ghidra] Detected overlap for variable var_ch
-// WARNING: [rz-ghidra] Failed to match type size_t for variable size to Decompiler type: Unknown type identifier size_t
 
 void sym.Aeropause(Bright *bright, int32_t argc, char **argv)
 {
@@ -2106,9 +1874,6 @@ NAME=typedef
 FILE=bins/dectest32
 EXPECT=<<EOF
 
-// WARNING: [rz-ghidra] Failed to match type unsigned long for variable arg_8h to Decompiler type: Unknown type
-// identifier unsigned long
-
 void sym.Aeropause(BrightPtr bright, Bright *argc, char **argv)
 {
     Morning *pMVar1;
@@ -2169,9 +1934,6 @@ void sym.Aeropause(BrightPtr bright, Bright *argc, char **argv)
 }
 --
 
-// WARNING: [rz-ghidra] Failed to match type unsigned long for variable arg_8h to Decompiler type: Unknown type
-// identifier unsigned long
-
 void sym.Aeropause(BrightTypedefd *bright, int32_t argc, char **argv)
 {
     Morning *pMVar1;
@@ -2231,9 +1993,6 @@ void sym.Aeropause(BrightTypedefd *bright, int32_t argc, char **argv)
     return;
 }
 --
-
-// WARNING: [rz-ghidra] Failed to match type unsigned long for variable arg_8h to Decompiler type: Unknown type
-// identifier unsigned long
 
 void sym.Aeropause(BrightTypedefdPtr bright, int32_t argc, char **argv)
 {
@@ -3124,10 +2883,6 @@ EOF
 EXPECT=<<EOF
 
 // WARNING: Switch with 1 destination removed at 0x080483e8
-// WARNING: [rz-ghidra] Failed to match type unsigned long for variable var_8h to Decompiler type: Unknown type
-// identifier unsigned long
-// WARNING: [rz-ghidra] Failed to match type ssize_t for variable var_ch to Decompiler type: Unknown type identifier
-// ssize_t
 // WARNING: [rz-ghidra] Detected overlap for variable var_dh
 
 void sym.imp.exit noreturn (void)
@@ -3135,6 +2890,39 @@ void sym.imp.exit noreturn (void)
     // WARNING: Treating indirect jump as call
     (**(code **)0x8049ffc)(0x30);
     return;
+}
+EOF
+RUN
+
+NAME=callables and atomic (jni)
+FILE=rizin-testbins/elf/jni/jniO0-arm64
+CMDS=<<EOF
+to bins/jni-simplified.h
+aaa
+s sym.Java_JNIFoo_nativeFoo
+afvr x0 env JNIEnv *
+afvr x1 obj jobject
+pdg
+EOF
+EXPECT=<<EOF
+
+jstring sym.Java_JNIFoo_nativeFoo(JNIEnv *env, jobject obj)
+{
+    int64_t iVar1;
+    jstring pvVar2;
+    void *var_18h;
+    void *ptr;
+    int64_t var_28h;
+    
+    iVar1 = sym.imp.malloc(0x1e);
+    if (iVar1 == 0) {
+        pvVar2 = (jstring)0x0;
+    } else {
+        sym.imp.memset(iVar1, 0, 0x1e);
+        pvVar2 = (*(*env)->NewStringUTF)(env, "foo: Test program of JNI.\\n");
+        sym.imp.free(0x650);
+    }
+    return pvVar2;
 }
 EOF
 RUN


### PR DESCRIPTION
Fix #49

Example:
<img width="1049" alt="Bildschirmfoto 2021-09-14 um 17 29 27" src="https://user-images.githubusercontent.com/1460997/133289734-ad589703-7774-49cb-8af5-62ac7011fe5c.png">
left is old, right is new + source. Notice how the `(*env)->NewStringUTF` gets resolved. The additional dereference seems to be the expected behavior of how the decompiler prints it. (In C, both a function and its pointer may be called directly)
