### PR TITLE
Enable Travis CI PPC64 job since it passes now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ jobs:
       name: S390X
       arch: s390x
       dist: focal
-    - os: linux
-      name: PPC64
-      arch: ppc64le
-      dist: focal
 
 addons:
   apt:


### PR DESCRIPTION
Only SystemZ allowed to fail now, because of https://github.com/rizinorg/rz-ghidra/issues/264