### PR TITLE
Remove RzIO dependency from SleighAsm

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -169,6 +169,8 @@ std::string StrToLower(std::string s)
 
 RZ_API std::string SleighIdFromSleighAsmConfig(const char *cpu, int bits, bool bigendian, const vector<LanguageDescription> &langs)
 {
+	if(!cpu)
+		return std::string();
 	if(std::string(cpu).find(':') != string::npos) // complete id specified
 		return cpu;
 	// short form if possible

--- a/src/analysis_ghidra.cpp
+++ b/src/analysis_ghidra.cpp
@@ -1402,7 +1402,8 @@ static int sleigh_op(RzAnalysis *a, RzAnalysisOp *analysis_op, ut64 addr, const 
 			return analysis_op->size;
 		}
 
-		SleighInstruction &ins = *sanalysis.trans.getInstruction(caddr);
+		std::unique_ptr<SleighInstruction> sinsn(sanalysis.trans.getInstruction(caddr));
+		SleighInstruction &ins = *sinsn;
 		FlowType ftype = ins.getFlowType();
 		bool isRefed = false;
 

--- a/src/analysis_ghidra.cpp
+++ b/src/analysis_ghidra.cpp
@@ -28,7 +28,7 @@ static int archinfo(RzAnalysis *analysis, int query)
 
 	try
 	{
-		sanalysis.init(analysis->cpu, analysis->bits, analysis->big_endian, analysis ? analysis->iob.io : nullptr, SleighAsm::getConfig(analysis));
+		sanalysis.init(analysis->cpu, analysis->bits, analysis->big_endian, SleighAsm::getConfig(analysis));
 	}
 	catch(const LowlevelError &e)
 	{
@@ -1382,7 +1382,7 @@ static int sleigh_op(RzAnalysis *a, RzAnalysisOp *analysis_op, ut64 addr, const 
 {
 	try
 	{
-		sanalysis.init(a->cpu, a->bits, a->big_endian, a? a->iob.io : nullptr, SleighAsm::getConfig(a));
+		sanalysis.init(a->cpu, a->bits, a->big_endian, SleighAsm::getConfig(a));
 
 		analysis_op->addr = addr;
 		analysis_op->sign = true;
@@ -1391,8 +1391,7 @@ static int sleigh_op(RzAnalysis *a, RzAnalysisOp *analysis_op, ut64 addr, const 
 		PcodeSlg pcode_slg(&sanalysis);
 		AssemblySlg assem(&sanalysis);
 		Address caddr(sanalysis.trans.getDefaultCodeSpace(), addr);
-		sanalysis.check(addr, data, len);
-		analysis_op->size = sanalysis.genOpcode(pcode_slg, caddr);
+		analysis_op->size = sanalysis.genOpcode(pcode_slg, caddr, data, len);
 		if((analysis_op->size < 1) || (sanalysis.trans.printAssembly(assem, caddr) < 1))
 			return analysis_op->size; // When current place has no available code, return ILL.
 
@@ -1490,10 +1489,12 @@ static int sleigh_op(RzAnalysis *a, RzAnalysisOp *analysis_op, ut64 addr, const 
 				{
 					char *reg = getIndirectReg(ins, isRefed);
 					if(reg)
+					{
 						if(isRefed)
 							analysis_op->ireg = reg;
 						else
 							analysis_op->reg = reg;
+					}
 
 					analysis_op->type = RZ_ANALYSIS_OP_TYPE_UCCALL;
 					analysis_op->fail = ins.getFallThrough().getOffset();
@@ -1794,7 +1795,7 @@ static char *get_reg_profile(RzAnalysis *analysis)
 
 	try
 	{
-		sanalysis.init(analysis->cpu, analysis->bits, analysis->big_endian, analysis ? analysis->iob.io : nullptr, SleighAsm::getConfig(analysis));
+		sanalysis.init(analysis->cpu, analysis->bits, analysis->big_endian, SleighAsm::getConfig(analysis));
 	}
 	catch(const LowlevelError &e)
 	{

--- a/src/asm_ghidra.cpp
+++ b/src/asm_ghidra.cpp
@@ -21,26 +21,8 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len)
 	try
 	{
 #endif
-		RzBin *bin = a->binb.bin;
-
-		if(!bin)
-		{
-			if(!rio)
-			{
-				rio = rz_io_new();
-				sasm.sleigh_id.clear(); // For newly created RzIO, refresh SleighAsm.
-			}
-			else
-				rz_io_close_all(rio);
-
-			RzBuffer *tmp_buf = rz_buf_new_with_bytes(buf, len);
-			rz_io_open_buffer(rio, tmp_buf, RZ_PERM_RWX, 0);
-			rz_buf_free(tmp_buf);
-		}
-
-		sasm.init(a->cpu, a->bits, a->big_endian, bin? bin->iob.io : rio, SleighAsm::getConfig(a));
-		sasm.check(bin? a->pc : 0, buf, len);
-		r = sasm.disassemble(op, bin? a->pc : 0);
+		sasm.init(a->cpu, a->bits, a->big_endian, SleighAsm::getConfig(a));
+		r = sasm.disassemble(op, a->pc, buf, len);
 #ifndef DEBUG_EXCEPTIONS
 	}
 	catch(const LowlevelError &e)


### PR DESCRIPTION
AsmLoadImage, the LoadImage used for disassembly is now just a simple
RzBuffer containing only the bytes currently disassembled and nothing
else.