### PR TITLE
Refine readonly ranges and enable ropropagate

### DIFF
--- a/src/RizinLoadImage.cpp
+++ b/src/RizinLoadImage.cpp
@@ -20,12 +20,39 @@ void RizinLoadImage::loadFill(uint1 *ptr, int4 size, const Address &addr)
 
 void RizinLoadImage::getReadonly(RangeList &list) const
 {
-	auto space = addr_space_manager->getDefaultCodeSpace();
 	RzCoreLock core(core_mutex);
+	std::set<RzCoreFile *> cf_visited;
+	auto space = addr_space_manager->getDefaultCodeSpace();
 	rz_vector_foreach_cpp<RzSkylineItem>(&core->io->map_skyline.v, [&](RzSkylineItem *skyscraper) {
 		auto map = reinterpret_cast<RzIOMap *>(skyscraper->user);
-		if((map->perm & RZ_PERM_W) || !skyscraper->itv.size)
+		if(!map->user || !skyscraper->itv.size)
 			return;
+		auto info = reinterpret_cast<RzCoreIOMapInfo *>(map->user);
+		if(!info->perm_orig || (info->perm_orig & RZ_PERM_W))
+		{
+			// Special case: objc maps pointers to e.g. the method name strings as rw unfortunately,
+			// but we want to have them propagated as constants.
+			// Similar to ObjectiveC2_ClassAnalyzer.setDataAndRefBlocksReadOnly, we just look for the
+			// sections by their name and force the ranges to read-only. This is under the assumption
+			// in here that if a RzBinMap comes from a corefile, then all of its RzBinFiles' sections
+			// are mapped at their contained vaddrs.
+			if(cf_visited.find(info->cf) != cf_visited.end())
+				return;
+			cf_visited.insert(info->cf);
+			rz_pvector_foreach_cpp<RzBinFile>(&info->cf->binfiles, [&](RzBinFile *bf) {
+				if(!bf->o || !bf->o->sections)
+					return true;
+				rz_list_foreach_cpp<RzBinSection>(bf->o->sections, [&](RzBinSection *sec) {
+					if(!sec->name || !sec->vsize)
+						return;
+					if(strstr(sec->name, "__objc_data") || strstr(sec->name, "__objc_classrefs") || strstr(sec->name, "__objc_msgrefs") ||
+						strstr(sec->name, "__objc_selrefs") || strstr(sec->name, "__objc_superrefs") || strstr(sec->name, "__objc_protorefs"))
+						list.insertRange(space, sec->vaddr, sec->vaddr + sec->vsize - 1);
+				});
+				return true;
+			});
+			return;
+		}
 		list.insertRange(space, skyscraper->itv.addr, skyscraper->itv.addr + skyscraper->itv.size - 1);
 	});
 }

--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -68,8 +68,8 @@ static const ConfigVar cfg_var_indent       ("indent",      "4",        "Indent 
 static const ConfigVar cfg_var_linelen      ("linelen",     "120",      "Max line length");
 static const ConfigVar cfg_var_maximplref   ("maximplref",  "2",        "Maximum number of references to an expression before showing an explicit variable.");
 static const ConfigVar cfg_var_rawptr       ("rawptr",      "true",     "Show unknown globals as raw addresses instead of variables");
-static const ConfigVar cfg_var_ropropagate  ("ropropagate", "false",    "Propagate read-only memory locations as constants");
-static const ConfigVar cfg_var_verbose      ("verbose",      "true",    "Show verbose warning messages while decompiling");
+static const ConfigVar cfg_var_ropropagate  ("ropropagate", "true",     "Propagate read-only memory locations as constants");
+static const ConfigVar cfg_var_verbose      ("verbose",     "true",     "Show verbose warning messages while decompiling");
 
 
 

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -2271,8 +2271,6 @@ CCu base64:Jg== @ 0x804858a
 <db>
 <property_changepoint space="ram" offset="0x8048000" val="0x2000"/>
 <property_changepoint space="ram" offset="0x80486bc" val="0x0"/>
-<property_changepoint space="ram" offset="0x8049f0c" val="0x2000"/>
-<property_changepoint space="ram" offset="0x804a024" val="0x0"/>
 <property_changepoint space="ram" offset="0x804a030" val="0x2000"/>
 <property_changepoint space="ram" offset="0x804a04c" val="0x0"/>
 <property_changepoint space="register" offset="0x1106" val="0x20000000"/>
@@ -2945,12 +2943,11 @@ pdg
 EOF
 EXPECT=<<EOF
 
-// WARNING: Switch with 1 destination removed at 0x080483e8
-
 void sym.imp.exit noreturn (void)
 {
+    // WARNING: Could not recover jumptable at 0x080483e8. Too many branches
     // WARNING: Treating indirect jump as call
-    (**(code **)0x8049ffc)(0x30);
+    (*_reloc.exit)();
     return;
 }
 EOF
@@ -2994,14 +2991,38 @@ FILE=rizin-testbins/mach0/hello-macos-arm64
 CMDS=<<EOF
 aaa
 s main
+?e ------------ with propagation
+e ghidra.ropropagate
+pdg
 ?e ------------ without propagation
 e ghidra.ropropagate=0
 pdg
-?e ------------ with propagation
-e ghidra.ropropagate=1
-pdg
 EOF
 EXPECT=<<EOF
+------------ with propagation
+true
+
+// WARNING: [rz-ghidra] Detected overlap for variable var_1ch
+
+undefined8 entry0(int64_t arg1, int64_t arg2)
+{
+    undefined4 uVar1;
+    undefined8 uVar2;
+    undefined8 uVar3;
+    int64_t var_18h;
+    
+    uVar2 = fcn.100003d9c();
+    uVar1 = (**(code **)0x100008188)(sym._a);
+    section.1.__TEXT.__stubs("");
+    uVar3 = fcn.100003d84(sym.class_Test);
+    fcn.100003da8(uVar3, "methodWithoutArgs");
+    fcn.100003da8(uVar3, "methodWithOneArg:", 0x7b);
+    fcn.100003da8(uVar3, "methodWithTwoArgs:secondArg:", 0x539, uVar1);
+    fcn.100003da8(uVar3, "methodWithReturn");
+    section.1.__TEXT.__stubs("");
+    fcn.100003d90(uVar2);
+    return 0;
+}
 ------------ without propagation
 
 // WARNING: [rz-ghidra] Detected overlap for variable var_1ch
@@ -3021,29 +3042,6 @@ undefined8 entry0(int64_t arg1, int64_t arg2)
     fcn.100003da8(uVar3, *(undefined8 *)0x1000080f8, 0x7b);
     fcn.100003da8(uVar3, *(undefined8 *)0x100008100, 0x539, uVar1);
     fcn.100003da8(uVar3, *(undefined8 *)0x100008108);
-    section.1.__TEXT.__stubs("");
-    fcn.100003d90(uVar2);
-    return 0;
-}
------------- with propagation
-
-// WARNING: [rz-ghidra] Detected overlap for variable var_1ch
-
-undefined8 entry0(int64_t arg1, int64_t arg2)
-{
-    undefined4 uVar1;
-    undefined8 uVar2;
-    undefined8 uVar3;
-    int64_t var_18h;
-    
-    uVar2 = fcn.100003d9c();
-    uVar1 = sym._something_else((int64_t)sym._a);
-    section.1.__TEXT.__stubs("");
-    uVar3 = fcn.100003d84(sym.class_Test);
-    fcn.100003da8(uVar3, "methodWithoutArgs");
-    fcn.100003da8(uVar3, "methodWithOneArg:", 0x7b);
-    fcn.100003da8(uVar3, "methodWithTwoArgs:secondArg:", 0x539, uVar1);
-    fcn.100003da8(uVar3, "methodWithReturn");
     section.1.__TEXT.__stubs("");
     fcn.100003d90(uVar2);
     return 0;


### PR DESCRIPTION
Readonly info is now by default taken from the original RzBinMap's
permissions rather than the RzIOMap ones because those are less
meaninful for decompilation.
Objc needs special treatment for nice decompilation with method strings
because its ref segments are mapped as rw.

Requires https://github.com/rizinorg/rizin/pull/2408