### PR TITLE
Make Travis CI System Z job mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ jobs:
       name: ARM64
       arch: arm64
       dist: focal
-  allow_failures:
-    - os: linux
-      name: S390X
-      arch: s390x
-      dist: focal
 
 addons:
   apt:


### PR DESCRIPTION
Now, that it is green, make it mandatory.

Closes https://github.com/rizinorg/rz-ghidra/issues/264