### PR TITLE
Register functions from reloc targets

### DIFF
--- a/src/RizinScope.cpp
+++ b/src/RizinScope.cpp
@@ -450,10 +450,16 @@ Symbol *RizinScope::registerFlag(RzFlagItem *flag) const
 				case RZ_STRING_ENC_UTF32BE:
 					tn = "char32_t";
 					break;
+				default:
+					break;
 			}
 		}
 		ptype = arch->types->findByName(tn);
 		int4 sz = static_cast<int4>(flag->size) / ptype->getSize();
+		if(!sz && str) // Zero string length is an error
+			sz = str->length;
+		if(!sz)
+			sz = 1; // The decompiler will figure out the length to display
 		type = arch->types->getTypeArray(sz, ptype);
 		attr |= Varnode::readonly;
 	}

--- a/src/RizinScope.h
+++ b/src/RizinScope.h
@@ -19,6 +19,7 @@ class RizinArchitecture;
 typedef struct rz_analysis_function_t RzAnalysisFunction;
 typedef struct rz_flag_item_t RzFlagItem;
 typedef struct rz_analysis_var_global_t RzAnalysisVarGlobal;
+typedef struct rz_bin_reloc_t RzBinReloc;
 
 class RizinScope : public Scope
 {
@@ -30,6 +31,7 @@ class RizinScope : public Scope
 		uint8 makeId() const { return (*next_id)++; }
 
 		FunctionSymbol *registerFunction(RzAnalysisFunction *fcn) const;
+		FunctionSymbol *registerRelocTarget(RzBinReloc *reloc) const;
 		Symbol *registerFlag(RzFlagItem *flag) const;
 		Symbol *registerGlobalVar(RzAnalysisVarGlobal *glob) const;
 		Symbol *queryRizinAbsolute(ut64 addr, bool contain) const;

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -3262,3 +3262,22 @@ undefined8 entry0(int64_t arg1, int64_t arg2)
 }
 EOF
 RUN
+
+NAME=reloc target functions
+FILE=rizin-testbins/elf/linux-example-x86-32.ko
+CMDS=<<EOF
+s sym.ko_example_init
+af
+pdg
+EOF
+EXPECT=<<EOF
+
+undefined4 sym.ko_example_init(void)
+{
+    // [04] -r-x section size 22 named .init.text
+    __fentry__();
+    printk("Hello, Rizin!\n");
+    return 0;
+}
+EOF
+RUN


### PR DESCRIPTION
Rizin shows calls to reloc targets as their function names in disassembly. We do the same in the decompiler.
Addresses #312