### PR TITLE
Remove use of rz_malloc()

### DIFF
--- a/src/CodeXMLParse.cpp
+++ b/src/CodeXMLParse.cpp
@@ -48,7 +48,7 @@ struct ParseCodeXMLContext
 static char *strdup_rz(const char *s)
 {
 	size_t sz = strlen(s);
-	char *r = reinterpret_cast<char *>(rz_malloc(sz + 1));
+	char *r = reinterpret_cast<char *>(rz_mem_alloc(sz + 1));
 	if(!r)
 		return NULL;
 	memcpy(r, s, sz + 1);
@@ -350,7 +350,7 @@ RZ_API RzAnnotatedCode *ParseCodeXML(Funcdata *func, const char *xml)
 	ParseNode(doc.child("function"), &ctx, ss, code);
 
 	std::string str = ss.str();
-	code->code = reinterpret_cast<char *>(rz_malloc(str.length() + 1));
+	code->code = reinterpret_cast<char *>(rz_mem_alloc(str.length() + 1));
 	if(!code->code)
 	{
 		rz_annotated_code_free(code);

--- a/src/analysis_ghidra.cpp
+++ b/src/analysis_ghidra.cpp
@@ -2937,9 +2937,7 @@ static bool esil_peek_n(RzAnalysisEsil *esil, int bits)
 		ut64 bitmask = genmask(bits - 1);
 		ut8 a[sizeof(ut64)] = {0};
 		ret = !!rz_analysis_esil_mem_read(esil, addr, a, bytes);
-		ut64 b = rz_read_ble64(a, 0); // esil->analysis->big_endian);
-		if(esil->analysis->big_endian)
-			rz_mem_swapendian((ut8 *)&b, (const ut8 *)&b, bytes);
+		ut64 b = rz_read_ble64(a, esil->analysis->big_endian);
 
 		snprintf(res, sizeof(res), "0x%" PFMT64x, b & bitmask);
 		rz_analysis_esil_push(esil, res);


### PR DESCRIPTION
Fixes the following error after https://github.com/rizinorg/rizin/commit/300fc28925e5ea04017520c6820063c327ffbb01 was merged:
```
47 [linux/amd64 stage-0 15/15] RUN cmake -DCMAKE_PREFIX_PATH=/tmp/***-install/usr -DCMAKE_INSTALL_PREFIX=/usr -B build && cmake --build build && DESTDIR=/tmp/***-install cmake --build build --target install
#47 178.9 [ 38%] Building CXX object CMakeFiles/core_ghidra.dir/src/RizinCommentDatabase.cpp.o
#47 181.1 [ 38%] Building CXX object CMakeFiles/core_ghidra.dir/src/CodeXMLParse.cpp.o
#47 182.5 /tmp/rz-ghidra/src/CodeXMLParse.cpp: In function 'char* strdup_rz(const char*)':
#47 182.5 /tmp/rz-ghidra/src/CodeXMLParse.cpp:51:37: error: 'rz_malloc' was not declared in this scope
#47 182.5   char *r = reinterpret_cast<char *>(rz_malloc(sz + 1));
#47 182.5                                      ^~~~~~~~~
#47 182.5 /tmp/rz-ghidra/src/CodeXMLParse.cpp:51:37: note: suggested alternative: 'rz_mem_alloc'
#47 182.5   char *r = reinterpret_cast<char *>(rz_malloc(sz + 1));
#47 182.5                                      ^~~~~~~~~
#47 182.5                                      rz_mem_alloc
#47 182.6 /tmp/rz-ghidra/src/CodeXMLParse.cpp: In function 'RzAnnotatedCode* ParseCodeXML(Funcdata*, const char*)':
#47 182.6 /tmp/rz-ghidra/src/CodeXMLParse.cpp:353:40: error: 'rz_malloc' was not declared in this scope
#47 182.6   code->code = reinterpret_cast<char *>(rz_malloc(str.length() + 1));
#47 182.6                                         ^~~~~~~~~
#47 182.6 /tmp/rz-ghidra/src/CodeXMLParse.cpp:353:40: note: suggested alternative: 'rz_mem_alloc'
#47 182.6   code->code = reinterpret_cast<char *>(rz_malloc(str.length() + 1));
#47 182.6                                         ^~~~~~~~~
#47 182.6                                         rz_mem_alloc
#47 183.1 make[2]: *** [CMakeFiles/core_ghidra.dir/build.make:141: CMakeFiles/core_ghidra.dir/src/CodeXMLParse.cpp.o] Error 1
#47 183.1 make[1]: *** [CMakeFiles/Makefile2:119: CMak
```