### PR TITLE
fix string being directly passed to printf (no "%s")

### DIFF
--- a/src/analysis_ghidra.cpp
+++ b/src/analysis_ghidra.cpp
@@ -1364,7 +1364,7 @@ static void sleigh_esil(RzAnalysis *a, RzAnalysisOp *analysis_op, ut64 addr, con
 	if(!esil_stack.empty())
 		ss << ",CLEAR";
 	// std::cerr << hex << analysis_op->addr << " " << ss.str() << endl;
-	esilprintf(analysis_op, ss.str()[0] == ','? ss.str().c_str() + 1: ss.str().c_str());
+	esilprintf(analysis_op, "%s", ss.str()[0] == ','? ss.str().c_str() + 1: ss.str().c_str());
 }
 
 /* Not in use for now.


### PR DESCRIPTION
hopefully there was no way there would be a `%` in the string either way, but this fixes compiling with some additional errors enabled (maybe `-Wformat -Wformat-security -Werror=format-security` would do it; when I attempted packaging rz-ghidra for NixOS it only errored out on MacOS, so perhaps there's a difference in behavior between gcc and clang)

There's another call to esilprintf with an empty string which causes a warning (`-Wformat-zero-length`).