### PR TITLE
Set "asm.arch" before the call to `SleighIDFromCore`

### DIFF
--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -474,10 +474,10 @@ static void PrintAutoSleighLang(RzCore *core)
 
 static void EnablePlugin(RzCore *core)
 {
+	rz_config_set(core->config, "asm.arch", "ghidra");
 	auto id = SleighIdFromCore(core);
 	rz_config_set(core->config, "ghidra.lang", id.c_str());
 	rz_config_set(core->config, "asm.cpu", id.c_str());
-	rz_config_set(core->config, "asm.arch", "ghidra");
 }
 
 bool SleighHomeConfig(void */* user */, void *data)


### PR DESCRIPTION
This way, the `strcmp` check in `SleighIDFromCore` function results as true, and in the corresponding branch, we extract the correct architecture using `SleighIdFromSleighAsmConfig`.

Before the fix:
```
[0x00000000]> pdga
WARNING: It is mandatory to have at least one argument register defined in the register profile.
WARNING: (null)
ERROR: core: cannot derive CC from reg profile.
WARNING: core: missing calling conventions for 'ghidra'. Deriving it from the regprofile.
[0x00000000]>
```

After the fix
```
[0x00006160]> pdga
[0x00006160]>
```

The above error is architecture and binary agnostic. Fixes https://im.rizin.re/rizinorg/pl/3xiabg1ah3naurrxmoq1ubxqca.