### PR TITLE
use Rzlist methods. fixes rizinorg/rz-ghidra#337

### DIFF
--- a/src/RizinUtils.h
+++ b/src/RizinUtils.h
@@ -11,9 +11,9 @@ typedef struct rz_list_iter_t RzListIter;
 
 template<typename T, typename F> void rz_list_foreach_cpp(RzList *list, const F &func)
 {
-	for(RzListIter *it = list->head; it; it = it->n)
+	for(RzListIter *it = list->head; it; it = rz_list_iter_get_next(it))
 	{
-		func(reinterpret_cast<T *>(it->data));
+		func(reinterpret_cast<T *>(rz_list_iter_get_data(it)));
 	}
 }
 

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -3138,13 +3138,10 @@ pdg
 EOF
 EXPECT=<<EOF
 
-// WARNING: Variable defined which should be unmapped: var_30h
-
 jstring sym.Java_JNIFoo_nativeFoo(JNIEnv *env, jobject obj)
 {
     int64_t iVar1;
     jstring pvVar2;
-    int64_t var_30h;
     
     iVar1 = sym.imp.malloc(0x1e);
     if (iVar1 == 0) {


### PR DESCRIPTION
Fixes compile errors resulting from the renaming of `rz_list_iter_t` members in rizin dev branch [here](https://github.com/rizinorg/rizin/commit/8fba9b41896b9d7ff3c2c4e8ad6808316daf59dc). New version calls methods instead of accessing members.