### PR TITLE
Use `rz_pvector_foreach_cpp` for `bf->o->sections`

### DIFF
--- a/src/RizinLoadImage.cpp
+++ b/src/RizinLoadImage.cpp
@@ -44,12 +44,13 @@ void RizinLoadImage::getReadonly(RangeList &list) const
 			rz_pvector_foreach_cpp<RzBinFile>(&info->cf->binfiles, [&](RzBinFile *bf) {
 				if(!bf->o || !bf->o->sections)
 					return true;
-				rz_list_foreach_cpp<RzBinSection>(bf->o->sections, [&](RzBinSection *sec) {
+				rz_pvector_foreach_cpp<RzBinSection>(bf->o->sections, [&](RzBinSection *sec) {
 					if(!sec->name || !sec->vsize)
-						return;
+						return true;
 					if(strstr(sec->name, "__objc_data") || strstr(sec->name, "__objc_classrefs") || strstr(sec->name, "__objc_msgrefs") ||
 						strstr(sec->name, "__objc_selrefs") || strstr(sec->name, "__objc_superrefs") || strstr(sec->name, "__objc_protorefs"))
 						list.insertRange(space, sec->vaddr, sec->vaddr + sec->vsize - 1);
+					return true;
 				});
 				return true;
 			});


### PR DESCRIPTION
This pr fixes the following error in the Rizin CI build, likely due to rizinorg/rizin#4089:

![rz_list_foreach_cpp-error](https://github.com/rizinorg/rz-ghidra/assets/12002672/72fd2477-cc5e-4aea-9c10-dfe6ea8e4065)
(https://github.com/rizinorg/rizin/actions/runs/7508868696/job/20446293652#step:9:11855)
