### PR TITLE
Do not use removed rz_bin_get_info() API

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -139,7 +139,10 @@ static const std::map<std::string, std::string> compiler_map = {
 
 std::string CompilerFromCore(RzCore *core)
 {
-	RzBinInfo *info = rz_bin_get_info(core->bin);
+	RzBinObject *bobj = rz_bin_cur_object(core->bin);
+	if (!bobj)
+		return std::string();
+	const RzBinInfo *info = rz_bin_object_get_info(bobj);
 	if (!info || !info->rclass)
 		return std::string();
 


### PR DESCRIPTION
Should fix the following error with the latest Rizin `dev`:
```
138.4 /tmp/rz-ghidra/src/ArchMap.cpp:142:20: error: 'rz_bin_get_info' was not declared in this scope
138.4   RzBinInfo *info = rz_bin_get_info(core->bin);
138.4                     ^~~~~~~~~~~~~~~
138.4 /tmp/rz-ghidra/src/ArchMap.cpp:142:20: note: suggested alternative: 'rz_bp_get_in'
138.4   RzBinInfo *info = rz_bin_get_info(core->bin);
138.4                     ^~~~~~~~~~~~~~~
138.4                     rz_bp_get_in
139.0 make[2]: *** [CMakeFiles/core_ghidra.dir/build.make:154: CMakeFiles/core_ghidra.dir/src/ArchMap.cpp.o] Error 1
139.0 make[1]: *** [CMakeFiles/Makefile2:119: CMakeFiles/core_ghidra.dir/all] Error 2
139.0 make: *** [Makefile:130: all] Error 2
------
```
Due to the https://github.com/rizinorg/rizin/commit/58808b2756927798ba71fa0a680f22500fcd0bfa