### PR TITLE
Force openssl in CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(rz-ghidra)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(Rizin REQUIRED Core)
+find_package(OpenSSL REQUIRED)
 
 set(RIZIN_INSTALL_PLUGDIR "${Rizin_PLUGINDIR}" CACHE STRING "Directory to install rizin plugins into")
 
@@ -80,6 +81,7 @@ endif()
 
 add_library(core_ghidra SHARED ${CORE_SOURCE})
 target_link_libraries(core_ghidra ghidra_libdecomp)
+target_link_libraries(core_ghidra ${OPENSSL_LIBRARIES})
 target_link_libraries(core_ghidra pugixml)
 target_link_libraries(core_ghidra Rizin::Core)
 set_target_properties(core_ghidra PROPERTIES
@@ -105,6 +107,7 @@ endif()
 if(BUILD_SLEIGH_PLUGIN)
 add_library(asm_ghidra SHARED ${ASM_SOURCE})
 target_link_libraries(asm_ghidra core_ghidra)
+target_link_libraries(asm_ghidra ${OPENSSL_LIBRARIES})
 set_target_properties(asm_ghidra PROPERTIES
 		OUTPUT_NAME asm_ghidra
 		BUILD_RPATH "${LD_RPATH_STR}"
@@ -113,6 +116,7 @@ set_target_properties(asm_ghidra PROPERTIES
 
 add_library(analysis_ghidra SHARED ${ANALYSIS_SOURCE})
 target_link_libraries(analysis_ghidra core_ghidra)
+target_link_libraries(analysis_ghidra ${OPENSSL_LIBRARIES})
 set_target_properties(analysis_ghidra PROPERTIES
 		OUTPUT_NAME analysis_ghidra
 		BUILD_RPATH "${LD_RPATH_STR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(ANALYSIS_SOURCE
 endif()
 
 add_library(core_ghidra SHARED ${CORE_SOURCE})
+target_include_directories(core_ghidra PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(core_ghidra ghidra_libdecomp)
 target_link_libraries(core_ghidra ${OPENSSL_LIBRARIES})
 target_link_libraries(core_ghidra pugixml)
@@ -106,6 +107,7 @@ endif()
 
 if(BUILD_SLEIGH_PLUGIN)
 add_library(asm_ghidra SHARED ${ASM_SOURCE})
+target_include_directories(asm_ghidra PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(asm_ghidra core_ghidra)
 target_link_libraries(asm_ghidra ${OPENSSL_LIBRARIES})
 set_target_properties(asm_ghidra PROPERTIES
@@ -115,6 +117,7 @@ set_target_properties(asm_ghidra PROPERTIES
 		PREFIX "")
 
 add_library(analysis_ghidra SHARED ${ANALYSIS_SOURCE})
+target_include_directories(analysis_ghidra PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(analysis_ghidra core_ghidra)
 target_link_libraries(analysis_ghidra ${OPENSSL_LIBRARIES})
 set_target_properties(analysis_ghidra PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(rz-ghidra)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(Rizin REQUIRED Core)
+find_package(OpenSSL REQUIRED)
 
 set(RIZIN_INSTALL_PLUGDIR "${Rizin_PLUGINDIR}" CACHE STRING "Directory to install rizin plugins into")
 
@@ -79,7 +80,9 @@ set(ANALYSIS_SOURCE
 endif()
 
 add_library(core_ghidra SHARED ${CORE_SOURCE})
+target_include_directories(core_ghidra PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(core_ghidra ghidra_libdecomp)
+target_link_libraries(core_ghidra ${OPENSSL_LIBRARIES})
 target_link_libraries(core_ghidra pugixml)
 target_link_libraries(core_ghidra Rizin::Core)
 set_target_properties(core_ghidra PROPERTIES
@@ -104,7 +107,9 @@ endif()
 
 if(BUILD_SLEIGH_PLUGIN)
 add_library(asm_ghidra SHARED ${ASM_SOURCE})
+target_include_directories(asm_ghidra PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(asm_ghidra core_ghidra)
+target_link_libraries(asm_ghidra ${OPENSSL_LIBRARIES})
 set_target_properties(asm_ghidra PROPERTIES
 		OUTPUT_NAME asm_ghidra
 		BUILD_RPATH "${LD_RPATH_STR}"
@@ -112,7 +117,9 @@ set_target_properties(asm_ghidra PROPERTIES
 		PREFIX "")
 
 add_library(analysis_ghidra SHARED ${ANALYSIS_SOURCE})
+target_include_directories(analysis_ghidra PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(analysis_ghidra core_ghidra)
+target_link_libraries(analysis_ghidra ${OPENSSL_LIBRARIES})
 set_target_properties(analysis_ghidra PROPERTIES
 		OUTPUT_NAME analysis_ghidra
 		BUILD_RPATH "${LD_RPATH_STR}"

--- a/scripts/Dockerfile.buster
+++ b/scripts/Dockerfile.buster
@@ -2,7 +2,7 @@
 FROM debian:buster
 
 RUN apt-get update
-RUN apt-get -y install git g++ cmake pkg-config flex bison python3 python3-pip ninja-build qt5-default libqt5svg5-dev qttools5-dev && \
+RUN apt-get -y install git g++ cmake pkg-config flex bison python3 python3-pip ninja-build qt5-default libqt5svg5-dev qttools5-dev libssl-dev openssl-dev && \
 	pip3 install meson
 
 RUN cd /root && \


### PR DESCRIPTION
Fixes https://github.com/rizinorg/rz-ghidra/issues/343

Hey guys. I'm having the same issue as https://github.com/rizinorg/rz-ghidra/issues/343. Here's the repro steps. My machine is MacOS M1 Monterey 12.6.6 and I'm on the [latest commit](https://github.com/rizinorg/rz-ghidra/commit/48fe3815a0434dadb35cc27032b6126a85c96c09) as of writing:

    git clone https://github.com/rizinorg/rz-ghidra
    cd rz-ghidra
    git submodule update --init
    # OpenSSL installed with homebrew
    pkg-config --cflags --libs openssl
    -I/opt/homebrew/Cellar/openssl@3/3.2.1/include -L/opt/homebrew/Cellar/openssl@3/3.2.1/lib -lssl -lcrypto
    cmake -DCMAKE_PREFIX_PATH=/Users/afjoseph/dev/misc/rizin/build -B build && cmake --build build --verbose
    
The build fails with the following error:


```
        [ 36%] Building CXX object CMakeFiles/core_ghidra.dir/src/core_ghidra.cpp.o
        /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DRZ_GHIDRA_SLEIGHHOME_DEFAULT=\"/usr/local/lib/rizin/plugins/rz_ghidra_sleigh\" -Dcore_ghidra_EXPORTS -I/Users/afjoseph/dev/misc/rz-ghidra/ghidra/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp -I/Users/afjoseph/dev/misc/rz-ghidra/third-party/pugixml/src -isystem /opt/homebrew/include/librz -isystem /opt/homebrew/include/librz/sdb -std=gnu++11 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -mmacosx-version-min=12.6 -fPIC -MD -MT CMakeFiles/core_ghidra.dir/src/core_ghidra.cpp.o -MF CMakeFiles/core_ghidra.dir/src/core_ghidra.cpp.o.d -o CMakeFiles/core_ghidra.dir/src/core_ghidra.cpp.o -c /Users/afjoseph/dev/misc/rz-ghidra/src/core_ghidra.cpp
        In file included from /Users/afjoseph/dev/misc/rz-ghidra/src/core_ghidra.cpp:9:
        In file included from /Users/afjoseph/dev/misc/rz-ghidra/src/ArchMap.h:10:
        In file included from /opt/homebrew/include/librz/rz_core.h:7:
        In file included from /opt/homebrew/include/librz/rz_main.h:9:
        In file included from /opt/homebrew/include/librz/rz_getopt.h:4:
        /opt/homebrew/include/librz/rz_util.h:21:10: fatal error: 'openssl/bn.h' file not found
        #include <openssl/bn.h>
                 ^~~~~~~~~~~~~~
        1 error generated.
        make[2]: *** [CMakeFiles/core_ghidra.dir/src/core_ghidra.cpp.o] Error 1
        make[1]: *** [CMakeFiles/core_ghidra.dir/all] Error 2
        make: *** [all] Error 2
```

This PR fixes tells CMake to require OpenSSL in the CMake targets, which would add the necessary compile flags (e.g., `pkg-config --cflags openssl`).
