### PR TITLE
Add tricore support

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -129,6 +129,8 @@ static const std::map<std::string, ArchMapper> arch_map = {
 		CUSTOM_BITS((RzCore *core) {
 			return 32;
 		})}},
+
+	{ "tricore", { "tricore" } },
 };
 
 static const std::map<std::string, std::string> compiler_map = {
@@ -185,7 +187,7 @@ RZ_API std::string SleighIdFromSleighAsmConfig(const char *cpu, int bits, bool b
 		auto proc = lang.getProcessor();
 		if(StrToLower(proc) == low_cpu)
 		{
-			return proc 
+			return proc
 				+ ":" + (bigendian ? "BE" : "LE")
 				+ ":" + to_string(bits)
 				+ ":" + "default";

--- a/src/RizinTypeFactory.cpp
+++ b/src/RizinTypeFactory.cpp
@@ -269,7 +269,9 @@ Datatype *RizinTypeFactory::fromRzTypeInternal(const RzType *ctype, string *erro
 			{
 				RzCoreLock core(arch->getCore());
 				char *tstr = rz_type_as_string(core->analysis->typedb, ctype);
-				*error = std::string("Failed to get any calling convention for callable ") + tstr;
+				if (error) {
+					*error = std::string("Failed to get any calling convention for callable ") + tstr;
+				}
 				rz_mem_free(tstr);
 				return nullptr;
 			}


### PR DESCRIPTION
```
[0x8000050e]> pdf 
            ; CALL XREF from loc.__no_board_init @ +0x20
            ;-- decrypt_end:
┌ int main(int argc, char **argv, char **envp);
│           ; arg int32_t arg5 @ a4
│           0x8000050e      mov.aa a14, sp
│           0x80000510      sub.a sp, #0x18
│           0x80000512      st.w [a14]#-0xc, d4
│           0x80000516      st.a [a14]#-0x10, a4                       ; arg5
│           0x8000051a      movh.a a2, #0x8001
│           0x8000051e      lea a2, [a2]#-0x7217
│           0x80000522      st.a [a14]#-4, a2
│           0x80000526      ld.a a4, [a14]#-4
│           0x8000052a      call  sym.decrypt                          ; sym.decrypt
│       ┌─< 0x8000052e      jne   d2, 0, 0x80000552
│       │   0x80000532      movh.a a2, #0x8001
│       │   0x80000536      lea a6, [a2]#-0x7206
│       │   0x8000053a      movh.a a2, #0x8001
│       │   0x8000053e      lea a5, [a2]#-0x71dc
│       │   0x80000542      mov d4, #0x23                              ; '#'
│       │   0x80000546      movh.a a2, #0x8001
│       │   0x8000054a      lea a4, [a2]#-0x71f9
│      ┌──< 0x8000054e      j     dbg.__assert_func                    ; dbg.__assert_func
│      │└─> 0x80000552      movh.a a2, #0xd000
│      │    0x80000556      lea a2, [a2]#8
│      │    0x8000055a      st.a [sp], a2
│      │    0x8000055c      movh.a a2, #0x8001
│      │    0x80000560      lea a4, [a2]#-0x71ed
│      │    0x80000564      call  dbg.printf                           ; dbg.printf ; int printf(const char *fmt)
│      │    0x80000568      mov d2, #0
└      │    0x8000056a      ret
```

```
[0x80000000]> pdg @ main

// WARNING: Unknown calling convention -- yet parameter storage is locked
// WARNING: [rz-ghidra] Matching calling convention reg of function main failed, args may be inaccurate.
// WARNING: [rz-ghidra] Matching calling convention reg of function sym.decrypt failed, args may be inaccurate.
// WARNING: [rz-ghidra] Matching calling convention reg of function dbg.fiprintf failed, args may be inaccurate.
// WARNING: [rz-ghidra] Failed to match type int (*anonymous_fcn_0x554)(struct _reent *anonymous_var_0x55e, void
// *anonymous_var_0x563, char *anonymous_var_0x568, int anonymous_var_0x56d) of member _read in struct __sFILE
// WARNING: [rz-ghidra] Failed to match type int (*anonymous_fcn_0x6c6)(struct _reent *anonymous_var_0x6d0, void
// *anonymous_var_0x6d5, const char *anonymous_var_0x6da, int anonymous_var_0x6df) of member _write in struct __sFILE
// WARNING: [rz-ghidra] Failed to match type _fpos_t (*anonymous_fcn_0x6f1)(struct _reent *anonymous_var_0x6fb, void
// *anonymous_var_0x700, _fpos_t anonymous_var_0x705, int anonymous_var_0x70a) of member _seek in struct __sFILE
// WARNING: [rz-ghidra] Failed to match type int (*anonymous_fcn_0x716)(struct _reent *anonymous_var_0x720, void
// *anonymous_var_0x725) of member _close in struct __sFILE
// WARNING: [rz-ghidra] Recursion detected while creating type __FILE
// WARNING: [rz-ghidra] Failed to match type __FILE * of member _stdin in struct _reent
// WARNING: [rz-ghidra] Failed to match type __FILE * of member _stdout in struct _reent
// WARNING: [rz-ghidra] Failed to match type __FILE * of member _stderr in struct _reent
// WARNING: [rz-ghidra] Failed to match type void (*anonymous_fcn_0x9d1)(struct _reent *anonymous_var_0x9d7) of member
// __cleanup in struct _reent
// WARNING: [rz-ghidra] Recursion detected while creating type _Bigint
// WARNING: [rz-ghidra] Failed to match type _Bigint * of member _next in struct _Bigint_0
// WARNING: [rz-ghidra] Failed to match type union anonymous_union_0x993 of member _new in struct _reent
// WARNING: [rz-ghidra] Failed to match type void (**anonymous_fcn_0x9e9)(int anonymous_var_0x9ef) of member _sig_func
// in struct _reent
// WARNING: [rz-ghidra] Failed to match type union anonymous_union_0x1be of member __value in struct
// anonymous_struct_0x1f5
// WARNING: [rz-ghidra] Matching calling convention reg of function dbg.abort failed, args may be inaccurate.
// WARNING: [rz-ghidra] Matching calling convention reg of function dbg.printf failed, args may be inaccurate.

undefined4 main(int32_t arg5)
{
    int32_t iVar1;
    char *in_a6;
    char *fmt;
    
    iVar1 = sym.decrypt(-0x7fff7217);
    if (iVar1 != 0) {
        dbg.printf(in_a6);
        return 0;
    }
    fmt = "decrypt(key)";
    do {
        dbg.fiprintf((FILE *)"assertion \"%s\" failed: file \"%s\", line %d%s%s\n", fmt);
        dbg.abort();
    } while( true );
}
```