### PR TITLE
Rename rz_list_first() to rz_list_first_val()

### DIFF
--- a/src/RizinCommentDatabase.cpp
+++ b/src/RizinCommentDatabase.cpp
@@ -25,7 +25,7 @@ void RizinCommentDatabase::fillCache(const Address &fad) const
 	{
 		RzList *fcns = rz_analysis_get_functions_in(core->analysis, fad.getOffset());
 		if(!rz_list_empty(fcns))
-			fcn = reinterpret_cast<RzAnalysisFunction *>(rz_list_first(fcns));
+			fcn = reinterpret_cast<RzAnalysisFunction *>(rz_list_first_val(fcns));
 		rz_list_free(fcns);
 	}
 	if(!fcn)

--- a/src/RizinScope.cpp
+++ b/src/RizinScope.cpp
@@ -528,7 +528,7 @@ Symbol *RizinScope::queryRizinAbsolute(ut64 addr, bool contain) const
 	{
 		RzList *fcns = rz_analysis_get_functions_in(core->analysis, addr);
 		if(!rz_list_empty(fcns))
-			fcn = reinterpret_cast<RzAnalysisFunction *>(rz_list_first(fcns));
+			fcn = reinterpret_cast<RzAnalysisFunction *>(rz_list_first_val(fcns));
 		rz_list_free(fcns);
 	}
 #endif


### PR DESCRIPTION
This pr renames rz_list_first() to rz_list_first_val() due to rizinorg/rizin#5654.