### PR TITLE
Use rz_list_next() instead of rz_list_iter_get_next()

### DIFF
--- a/src/RizinUtils.h
+++ b/src/RizinUtils.h
@@ -11,7 +11,7 @@ typedef struct rz_list_iter_t RzListIter;
 
 template<typename T, typename F> void rz_list_foreach_cpp(RzList *list, const F &func)
 {
-	for(RzListIter *it = list->head; it; it = rz_list_iter_get_next(it))
+	for(RzListIter *it = list->head; it; it = rz_list_next(it))
 	{
 		func(reinterpret_cast<T *>(rz_list_iter_get_data(it)));
 	}


### PR DESCRIPTION
This pr renames rz_list_iter_get_next() to rz_list_next() in the code due to rizinorg/rizin#5696 and rizinorg/rizin#5710.