### PR TITLE
Use rz_list_val() instead of rz_list_iter_get_data()

### DIFF
--- a/src/RizinUtils.h
+++ b/src/RizinUtils.h
@@ -13,7 +13,7 @@ template<typename T, typename F> void rz_list_foreach_cpp(RzList *list, const F 
 {
 	for(RzListIter *it = list->head; it; it = rz_list_next(it))
 	{
-		func(reinterpret_cast<T *>(rz_list_iter_get_data(it)));
+		func(reinterpret_cast<T *>(rz_list_val(it)));
 	}
 }
 


### PR DESCRIPTION
This pr renames rz_list_iter_get_data() to rz_list_val() in the code due to rizinorg/rizin#5900.