### PR TITLE
Use C++20 for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,10 @@ endif()
 
 if(CMAKE_VERSION VERSION_LESS "3.1")
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-		add_definitions(-std=c++11)
+		add_definitions(-std=c++20)
 	endif()
 else()
-	set(CMAKE_CXX_STANDARD 11)
+	set(CMAKE_CXX_STANDARD 20)
 endif()
 
 add_subdirectory(ghidra)

--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -43,7 +43,7 @@ template <> class Mapper<bool> : public BaseMapper<bool> {
 template <> class Mapper<std::string> : public BaseMapper<std::string> {
     public:
 	using BaseMapper<std::string>::BaseMapper;
-	Mapper<std::string>(const char *constant)
+	Mapper(const char *constant)
 		: BaseMapper([constant](RzCore *core) { return constant; })
 	{
 	}


### PR DESCRIPTION
This pr uses C++20 for the build to fix errors of the following form in rizinorg/cutter#3554:

<img width="1272" height="121" alt="ghidra-c++20" src="https://github.com/user-attachments/assets/10ce55ac-2c0e-44d8-903b-56718c3a0f29" />

(https://github.com/rizinorg/cutter/actions/runs/22096335762/job/63854269453#step:9:12682)

The reasoning for the change is basically the same as in https://github.com/rizinorg/jsdec/pull/67#issuecomment-3914066220.