### PR TITLE
Fix pdgsd command print function for correct pcode #172

### DIFF
--- a/src/core_ghidra.cpp
+++ b/src/core_ghidra.cpp
@@ -375,10 +375,10 @@ class PcodeRawOut : public PcodeEmit
 	              int4 isize) override
 	    {
 		    std::stringstream ss;
+		    bool is_store = false;
 		    if(opc == CPUI_STORE && isize == 3)
 		    {
-			    print_vardata(ss, vars[2]);
-			    ss << " = ";
+			    is_store = true;
 			    isize = 2;
 		    }
 		    if(outvar)
@@ -411,6 +411,11 @@ class PcodeRawOut : public PcodeEmit
 				    ss << ", ";
 					print_vardata(ss, vars[i]);
 			    }
+		    }
+		    if(is_store)
+		    {
+			    ss << " = ";
+			    print_vardata(ss, vars[2]);
 		    }
 			rz_cons_printf("    %s\n", ss.str().c_str());
 	    }

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -2904,6 +2904,7 @@ shr eax, 4
 0x08048540: PUSH EBP
     (unique,0x9b80,4) = COPY EBP
     ESP = INT_SUB ESP, 0x4
+    STORE ram[ESP] = (unique,0x9b80,4)
 0x08048541: MOV EBP,ESP
     EBP = COPY ESP
 0x08048543: SUB ESP,0x88
@@ -2991,7 +2992,7 @@ CMDS=<<EOF
 s main
 pi 8
 echo -----
-pdgsd 8~!STORE
+pdgsd 8
 EOF
 RUN
 


### PR DESCRIPTION
Fixes #172 

What changed?
The components of the memory reference ram[ESP] are formatted using the AddrSpace extraction and the assignment value (unique,0x12f0,4) is neatly placed on the right side of the = operator.

Previously, users would see:
Formatting STORE instructions produced output like: `(unique,0x12f0,4) = STORE ram[ESP]`

Now, users will see:
This produces output like: `STORE ram[ESP] = (unique,0x1b50,4)`