### PR TITLE
Sync `RzGhidraDecompiler::decompileAt()` definition and declaration

### DIFF
--- a/cutter-plugin/RzGhidraDecompiler.cpp
+++ b/cutter-plugin/RzGhidraDecompiler.cpp
@@ -16,7 +16,7 @@ RzGhidraDecompiler::RzGhidraDecompiler(QObject *parent)
 	task = nullptr;
 }
 
-void RzGhidraDecompiler::decompileAt(ut64 addr)
+void RzGhidraDecompiler::decompileAt(RVA addr)
 {
 	if(task)
 		return;


### PR DESCRIPTION
This pr synchronizes `RzGhidraDecompiler::decompileAt()`'s definition with its declaration and fixes the following error:

<img width="1230" height="222" alt="decompileAt" src="https://github.com/user-attachments/assets/cbec8061-ac6e-4f0a-ad3f-c2b1c331a24c" />

(https://github.com/rizinorg/cutter/actions/runs/24929390645/job/73004593080?pr=3608#step:10:10650)

with regard to rizinorg/cutter#3608.

