### PR TITLE
Resolve sleigh language id by the processor's available endianness

### DIFF
--- a/src/ArchMap.cpp
+++ b/src/ArchMap.cpp
@@ -227,14 +227,32 @@ SleighIdFromSleighAsmConfig(const char *cpu, int bits, bool bigendian,
 		return std::string();
 	if (std::string(cpu).find(':') != string::npos) // complete id specified
 		return cpu;
-	// short form if possible
+	// short form: resolve against the available sleigh languages so we honor
+	// the endianness the processor actually ships rather than assuming the
+	// host/config default. Some processors are single-endian (e.g. V850 is
+	// little-endian only), which previously produced an unusable id such as
+	// "V850:BE:32" on big-endian hosts and broke disassembly there.
 	std::string low_cpu = StrToLower(cpu);
+	std::string proc_name;
+	bool has_be = false, has_le = false;
 	for (const auto &lang : langs) {
-		auto proc = lang.getProcessor();
-		if (StrToLower(proc) == low_cpu) {
-			return proc + ":" + (bigendian ? "BE" : "LE") + ":" +
-			       to_string(bits) + ":" + "default";
-		}
+		if (StrToLower(lang.getProcessor()) != low_cpu)
+			continue;
+		proc_name = lang.getProcessor();
+		if (lang.getSize() != bits)
+			continue;
+		if (lang.isBigEndian())
+			has_be = true;
+		else
+			has_le = true;
 	}
-	return cpu;
+	if (proc_name.empty())
+		return cpu;
+	bool be = bigendian;
+	if (be && !has_be && has_le)
+		be = false;
+	else if (!be && !has_le && has_be)
+		be = true;
+	return proc_name + ":" + (be ? "BE" : "LE") + ":" + to_string(bits) +
+	       ":" + "default";
 }


### PR DESCRIPTION
Fixes #389.

### Problem
`SleighIdFromSleighAsmConfig` builds the language id as `proc:(bigendian?BE:LE):bits` straight from the host/config endianness, without checking that the combination has a sleigh spec. For single-endian processors this yields an unusable id on the wrong host.

Concretely, V850 is little-endian only, so on a big-endian host the id resolves to `V850:BE:32`, there is no spec for it (`SleighInit No sleigh specification for V850:BE:32`), and every instruction decodes as `invalid` (the `v850load` and `v850cmp` tests that flagged this).

### Fix
Match the requested cpu against the available `LanguageDescription`s and, when the requested endianness has no spec but the opposite one does, use the one that actually exists. When the requested endianness is available the result is unchanged, so little-endian hosts behave exactly as before (no behavior change there).

### Verification
This is the path your big-endian CI exercised in #389, so the `extras/analysis_ghidra` `v850load` / `v850cmp` cases that produced `V850:BE:32` should go from failing to passing once CI runs on a big-endian runner. I diagnosed it from the failing trace and the language-resolution logic; happy to adjust if you'd prefer a stricter match (e.g. also keying on variant).