### PR TITLE
Do not propagate import slots as read-only constants

### DIFF
--- a/src/RizinLoadImage.cpp
+++ b/src/RizinLoadImage.cpp
@@ -20,6 +20,40 @@ void RizinLoadImage::loadFill(uint1 *ptr, int4 size, const Address &addr)
 	rz_io_read_at_mapped(core->io, addr.getOffset(), ptr, size);
 }
 
+namespace {
+
+struct ImportSlotCtx {
+	RangeList *list;
+	AddrSpace *space;
+	RzIO *io;
+	ut64 slot_size;
+};
+
+// Punch one import slot out of the read-only ranges. The loader owns a slot's
+// value, so it is a property of a process and never a constant of the program.
+// Unbound it is a hint/name table RVA; in a dump, one run's resolved address.
+bool subtract_import_slot(RzFlagItem *fi, void *user)
+{
+	auto ctx = reinterpret_cast<ImportSlotCtx *>(user);
+	RzIOMap *map = rz_io_map_get(ctx->io, fi->offset);
+	if(!map || !map->user)
+		return true;
+	auto info = reinterpret_cast<RzCoreIOMapInfo *>(map->user);
+	// On ELF these flags sit on PLT stubs, not slots; the GOT slots behind them
+	// already resolve by name through their relocs.
+	if(info->perm_orig & RZ_PERM_X)
+		return true;
+	// fi->size is not the slot extent: PE import flags carry 0, ELF ones the
+	// length of the PLT stub.
+	ut64 last = fi->offset + ctx->slot_size - 1;
+	if(last < fi->offset) // slot at the very top of the space
+		return true;
+	ctx->list->removeRange(ctx->space, fi->offset, last);
+	return true;
+}
+
+} // namespace
+
 void RizinLoadImage::getReadonly(RangeList &list) const
 {
 	RzCoreLock core(core_mutex);
@@ -58,6 +92,15 @@ void RizinLoadImage::getReadonly(RangeList &list) const
 		}
 		list.insertRange(space, skyscraper->itv.addr, skyscraper->itv.addr + skyscraper->itv.size - 1);
 	});
+
+	// The loop above judges read-only from permissions alone, which sweeps in the
+	// PE IAT because it lives in .rdata. Subtract those slots again.
+	RzSpace *imports_space = rz_flag_space_get(core->flags, RZ_FLAGS_FS_IMPORTS);
+	if(imports_space)
+	{
+		ImportSlotCtx ctx = { &list, space, core->io, space->getAddrSize() };
+		rz_flag_foreach_space(core->flags, imports_space, subtract_import_slot, &ctx);
+	}
 }
 
 string RizinLoadImage::getArchType() const

--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -3405,6 +3405,69 @@ int64_t dbg.main(void)
 EOF
 RUN
 
+# The switch table and string literals below are load-bearing: they prove that
+# read-only propagation still works for everything that is not an import slot.
+NAME=readonlypropagate imports (PE)
+FILE=rizin-testbins/jmptbl/test_switch_indirect.exe
+CMDS=<<EOF
+aaa
+pdg @ main
+EOF
+EXPECT=<<EOF
+
+undefined8 main(int argc)
+{
+    char *s;
+    
+    // [00] -r-x section size 4096 named .text
+    (*_sym.imp.api_ms_win_crt_utility_l1_1_0.dll_srand)();
+    // switch table (99 cases) at 0x140001148
+    switch(argc) {
+    case 1:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 1");
+        return 0;
+    case 2:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 2");
+        return 0;
+    default:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)(s);
+        return 0;
+    case 10:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 10");
+        return 0;
+    case 0xb:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 11");
+        return 0;
+    case 0xd:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 13");
+        return 0;
+    case 0xf:
+    case 0x10:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 15 and 16");
+        return 0;
+    case 0x13:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 19");
+        return 0;
+    case 0x14:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 20");
+        return 0;
+    case 0x1e:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 30");
+        return 0;
+    case 0x32:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 50");
+        return 0;
+    case 0x61:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 97");
+        return 0;
+    case 99:
+        (*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)("case 99");
+        return 0;
+    }
+}
+EOF
+RUN
+
 NAME=reloc target functions
 FILE=rizin-testbins/elf/linux-example-x86-32.ko
 CMDS=<<EOF


### PR DESCRIPTION
### Problem

On PE, calls to imported functions decompile to a raw pointer instead of the API name:

```c
(*(code *)0x2af4)("case 1");
```

The IAT sits in `.rdata` (MSVC merges `.idata$5` into it), so `getReadonly()` hands it to the decompiler as constant data. A call through a slot then folds into the file's at-rest bytes before `RizinScope` can name it.

### Fix

Subtract the import slots from the read-only ranges, instead of turning read-only propagation off globally with `ghidra.ropropagate=0`. Everything else that is read-only keeps propagating.

Flags in executable mappings are skipped, so ELF is unaffected. There the flags sit on PLT stubs, and the GOT slots behind them already resolve by name through their relocations.

This leaves the `(*name)(...)` call wrapper (#69) in place, which is a separate matter of registering imports as functions rather than code pointers. Its wider cause is that the PE loader attaches no import info to the IAT relocations (#375), which also disables the reloc-based tail-call override in `PcodeFixupPreprocessor`. Fixing that in rizin would cover several PE cases at once.

### Test

`readonlypropagate imports (PE)`, next to the existing `readonlypropagate (objc)` in `test/db/extras/ghidra`, decompiles `main` in `rizin-testbins/jmptbl/test_switch_indirect.exe`. The 14 imported calls gain their names (`(*(code *)0x2af4)` becomes `(*_sym.imp.api_ms_win_crt_stdio_l1_1_0.dll_puts)`) while the 99-case switch table and its strings stay intact.

- fails on `dev`, passes with this change
- `rz-test -L db/extras`: 54 OK / 1 BR / 0 XX, the BR being the pre-existing `NAME=typedef`

Built against rizin `dev` HEAD.

> [!NOTE]
> Opus 5 was used to investigate the behavior and to draft the patch and test, which I reviewed and verified myself.

Ref #375 (the PE raw-pointer half). Related to #69 and #229.
